### PR TITLE
docs: record Cloudflare GitHub App access

### DIFF
--- a/docs/stage-hosting.md
+++ b/docs/stage-hosting.md
@@ -31,6 +31,10 @@ hard-coded.
 | Non-production deploy command | `npm run stage:preview` |
 | Builds for non-production branches | enabled |
 
+The `Cloudflare Workers and Pages` GitHub App must retain explicit access to
+`kiaquila/fathom`. Public read access is enough for a manual clone, but not for
+the push webhooks that start production and preview builds.
+
 `workers_dev: true` keeps the stable workers.dev route available and
 `preview_urls: true` enables versioned previews. `run_worker_first: true`
 ensures the security headers in `website/worker/index.ts` are attached to every


### PR DESCRIPTION
## Summary

- record that the Cloudflare GitHub App needs explicit access to this repository
- use this focused change to verify non-production and production Workers Builds triggers end to end

## Verification

- `npm run preflight`
- GitHub checks: `validate`, `osv-scan`, and `Workers Builds: fathom` passed
- Cloudflare preview: https://codex-verify-cloudflare-deploy-fathom.ks-design.workers.dev
- preview root and SPA fallback return HTTP 200 with the expected security headers and `X-Robots-Tag: noindex`
- production deployment from `main`: https://dash.cloudflare.com/7f84bdf4279121edf62bc07caf300da2/workers/services/view/fathom/production/builds/71fb799c-b9b7-4d75-a79a-3cbc5a72ab03
- production root and SPA fallback return HTTP 200 at https://fathom.ks-design.art

Co-authored-by: Codex <codex@openai.com>