### PR TITLE
fix: graphite control stroke and seam-free tail wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ that follows the visitor's local time of day.
   facing right, cut out on a transparent ground. At load the engine scales
   each picture per depth plane, grades it for the mood, and samples its
   brightest sequins as glint sites; the tail still runs as a travelling wave
-  because the sprite is drawn in vertical strips. `?fish=drawn` keeps the
+  because the sprite is drawn in vertical strips (assembled on whole pixels
+  on a scratch canvas, so the translucent fins show no seams). `?fish=drawn` keeps the
   earlier procedural school for side-by-side review, and it also stands in
   automatically if the pictures fail to load or do not arrive within eight
   seconds (whatever has loaded by then is used).

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -24,6 +24,8 @@
        Brand dot only; the artwork palette and UI states stay on --gold. */
     --brand-dot-a: #818cf8;
     --brand-dot-b: #22d3ee;
+    /* pinned-button border and focus ring: graphite, softer than the ink on the day water */
+    --stroke: #52565a;
   }
   body[data-mood="dusk"] {
     --bg: #5b7085;
@@ -33,6 +35,7 @@
     --pill: rgba(255, 255, 255, 0.1);
     --pill-on: rgba(255, 255, 255, 0.3);
     --gold: #e6b45c;
+    --stroke: #f1ede5;
   }
   body[data-mood="midnight"] {
     --bg: #0c141c;
@@ -42,6 +45,7 @@
     --pill: rgba(255, 255, 255, 0.08);
     --pill-on: rgba(255, 255, 255, 0.24);
     --gold: #e8b95a;
+    --stroke: #ece8e0;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html, body { height: 100%; }
@@ -141,8 +145,8 @@
   }
   .ctl:hover { background: var(--pill-on); }
   .ctl:active { transform: scale(0.96); }
-  .ctl[aria-pressed="true"] { background: var(--pill-on); border-color: var(--ink); }
-  .ctl:focus-visible { outline: 2px solid var(--ink); outline-offset: 3px; }
+  .ctl[aria-pressed="true"] { background: var(--pill-on); border-color: var(--stroke); }
+  .ctl:focus-visible { outline: 2px solid var(--stroke); outline-offset: 3px; }
   footer {
     text-align: center;
     padding-top: 2px;
@@ -160,7 +164,7 @@
     transition: border-color 0.2s ease, color 0.2s ease;
   }
   footer a:hover { border-color: var(--gold); color: var(--gold); }
-  footer a:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+  footer a:focus-visible { outline: 2px solid var(--stroke); outline-offset: 2px; }
   @media (max-width: 560px) {
     .top { padding: 16px 18px; }
     .tag { font-size: 10px; letter-spacing: 0.16em; }
@@ -411,11 +415,23 @@ function glowSprite(sp, color, px) { const c = document.createElement('canvas');
 
 /* ---------- drawing: veil tail waves more, slower ---------- */
 function wiggleOff(sp, t, phase, wig) { return wig * sp.hpx * 0.075 * Math.pow(t, 1.6) * Math.sin(phase - t * 2.8); }
+/* The wave is assembled at sprite resolution on a shared scratch canvas: every slice starts and ends on a
+   whole pixel and none overlaps its neighbour, so no seam and no double-covered column shows on the
+   translucent fins. The warped sprite then lands on the scene with a single scaled, rotated blit. */
+let warp = null;
+function warpSprite(sp, phase, wig, slices) {
+  const W = sp.w, Hh = sp.h, pad = Math.ceil(Math.abs(wig) * sp.hpx * 0.075) + 1, H2 = Hh + pad * 2;
+  if (!warp) { const c = document.createElement('canvas'); warp = { canvas: c, ctx: c.getContext('2d') }; }
+  if (warp.canvas.width < W) warp.canvas.width = W; if (warp.canvas.height < H2) warp.canvas.height = H2;
+  const x = warp.ctx; x.clearRect(0, 0, W, H2);
+  for (let i = 0, sx = 0; i < slices; i++) { const ex = Math.round((i + 1) * W / slices), sw = ex - sx; if (sw <= 0) continue; const t = 1 - (sx + sw / 2) / W; x.drawImage(sp.canvas, sx, 0, sw, Hh, sx, pad + wiggleOff(sp, t, phase, wig), sw, Hh); sx = ex; }
+  return { canvas: warp.canvas, w: W, h: H2, pad };
+}
 function drawFish(ctx, sp, x, y, o) {
   o = o || {}; const angle = o.angle || 0, scale = o.scale || 1, phase = o.phase || 0, wig = o.wig == null ? 1 : o.wig, alpha = o.alpha == null ? 1 : o.alpha, slices = o.slices || 18;
   ctx.save(); ctx.translate(x, y); ctx.rotate(angle); if (o.flip) ctx.scale(-1, 1); const k = scale / sp.ss; ctx.scale(k, k); if (alpha !== 1) ctx.globalAlpha *= alpha;
-  const W = sp.w, Hh = sp.h, sw = W / slices;
-  for (let i = 0; i < slices; i++) { const sx = i * sw, t = 1 - (sx + sw / 2) / W; ctx.drawImage(sp.canvas, sx, 0, sw + 1, Hh, -W / 2 + sx, -Hh / 2 + wiggleOff(sp, t, phase, wig), sw + 1, Hh); }
+  const W = sp.w, Hh = sp.h, wp = warpSprite(sp, phase, wig, slices);
+  ctx.drawImage(wp.canvas, 0, 0, wp.w, wp.h, -W / 2, -Hh / 2 - wp.pad, wp.w, wp.h);
   if (o.glints && o.glints.length) { ctx.globalCompositeOperation = 'lighter';
     for (const gl of o.glints) { const tl = sp.tiles[gl.i]; if (!tl) continue; const a = Math.sin(Math.PI * gl.t / gl.life) * gl.k; if (a <= 0.01) continue; const t = 1 - (tl.x + W / 2) / W, off = wiggleOff(sp, t, phase, wig);
       ctx.save(); ctx.translate(tl.x, tl.y + off); ctx.globalAlpha = a * 0.85 * alpha; ctx.fillStyle = gl.color; ctx.beginPath(); ctx.arc(0, 0, tl.r * 1.25, 0, TAU); ctx.fill();


### PR DESCRIPTION
## Summary

- What changed: two things on the published page. (1) The pinned mood button's border and the `:focus-visible` rings (buttons and the footer link) take a new `--stroke` token instead of the ink: graphite `#52565a` on the day water; dusk and midnight keep their light ink as the stroke. (2) The painted fish no longer show vertical seams on their translucent tails and fins. `drawFish` used to place each of the 14–22 wave strips straight onto the scene at fractional positions, one pixel wider than its neighbour, so the overlaps and the anti-aliased strip edges read as evenly spaced stripes on the veil fins. The strips are now assembled on a shared scratch canvas at sprite resolution on whole pixels without overlap, and the warped sprite lands on the scene with one scaled, rotated blit. The travelling tail wave, the glints and the glow path are unchanged.
- Why: client decision (Kristina, 2026-09-04) after a side-by-side of twenty greys for the stroke — the ink read as black against the day water — and after comparing the fish pictures rendered plainly with the same pictures on the live canvas, where the stripes on the tails were the only difference.
- Product surface affected: the published page (`website/src/index.html`: three CSS custom properties, two selectors, `drawFish`); README artwork note.

## Content and design evidence

- [x] Facts and copy are sourced or explicitly marked as assumptions — no copy changes; the stroke colour is a client choice recorded in this PR.
- [x] Third-party assets, fonts, scripts, embeds, and trackers are licensed and justified — none added; the fish pictures are unchanged.
- [x] Smallest/largest layouts, keyboard, reduced motion, and the critical path were checked — see evidence.
- [x] README, AGENTS, and durable product docs still match the implementation — README's note on the tail wave now mentions the seam-free strip assembly.

## Safety and validation

- [x] No secrets, personal paths, generated output, or unrelated customer data are tracked.
- [x] `npm run preflight` — repository guard, harness tests (14/14), website build + tests (6/6), budget check: all green.
- [x] Payload-budget result: **447 KB raw / 407 KB gzip, critical 18.7 KB gzip** (budgets 1.5 MB raw / 512 KB gzip / 45 KB critical gzip). No budget change; the page grows by about 650 bytes gzip over main.

## Evidence

- `npm run preflight` locally after rebasing onto main (#5, brand dot and no mood caption): `Payload: 446610 B raw, 406561 B gzip; critical 18749 B gzip`. The rebase touched one hunk: `--stroke` now sits after the brand-dot variables in `:root`.
- Headless Chrome 1400×800 at DPR 2, `?mood=day`, main vs. this branch: on main the big fish's tail and pectoral fin show vertical seams at strip boundaries; on this branch the fins are continuous. The wave, depth blur, fog and glints render as before. The pinned `day` button shows the graphite border.
- Mobile (375×812, DPR 2): chrome and controls fit as before; fins are seam-free at the small sizes too.
- `?motion=reduce`: a single still frame renders with the new stroke and seam-free fins.
- Keyboard: the focus rings are the same `:focus-visible` rules as before with the colour swapped to `--stroke`; verified in the source and the shipped page, not by a keyboard pass in a browser.
- Performance: per fish per frame the change adds one `clearRect` and one sprite-sized blit on the scratch canvas; the number and area of strip draws is unchanged.
- Not run: Safari and Firefox; the OS-level reduced-motion setting (only the URL override); a screen reader pass; Wrangler deploy (Cloudflare builds the branch preview itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
