### PR TITLE
Require current-head Codex review before merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,4 +14,4 @@ scripts/config.mjs                   linguist-vendored
 scripts/publish-codex-review-check.mjs linguist-vendored
 scripts/run-project-checks.mjs       linguist-vendored
 tests/harness.test.mjs               linguist-vendored
-tests/codex-review.test.mjs          linguist-vendored
+tests/codex-review-gate.test.mjs     linguist-vendored

--- a/.github/workflows/codex-review-request.yml
+++ b/.github/workflows/codex-review-request.yml
@@ -1,0 +1,32 @@
+name: Codex Review Request
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  # GITHUB_TOKEN rejects PR issue-comment creation with issues: write alone.
+  pull-requests: write
+
+jobs:
+  codex-review-request:
+    name: codex-review-request
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '@codex') &&
+      contains(github.event.comment.body, 'review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted request policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Record trusted current-head request
+        run: node scripts/codex-review-request.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/codex-review-rerun.yml
+++ b/.github/workflows/codex-review-rerun.yml
@@ -1,0 +1,43 @@
+name: Codex Review Rerun
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  codex-review-rerun:
+    name: codex-review-rerun
+    if: |
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.user.login == 'chatgpt-codex-connector[bot]'
+      ) ||
+      (
+        github.event.issue.pull_request &&
+        github.event.comment.user.login == 'chatgpt-codex-connector[bot]' &&
+        startsWith(github.event.comment.body, 'Codex Review:')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted rerun policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Rerun gate for trusted Codex evidence
+        run: |
+          if [ ! -f scripts/codex-review-rerun.mjs ]; then
+            echo "Codex Review bootstrap is not installed on the default branch yet; the pull-request gate handles this installation PR."
+            exit 0
+          fi
+          node scripts/codex-review-rerun.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,113 @@
+name: Codex Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to validate
+        required: true
+      head_sha:
+        description: Current pull request head SHA to validate
+        required: true
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    name: Codex Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout proposed repository state
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || inputs.head_sha || github.sha }}
+
+      - name: Checkout trusted Codex review gate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .codex-review-trusted
+          fetch-depth: 1
+
+      - name: Validate current-head Codex review
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CODEX_REVIEW_PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          CODEX_REVIEW_HEAD_SHA: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.sha }}
+          CODEX_REVIEW_REQUIRE_HEAD_MATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          CODEX_REVIEW_WAIT_MS: "30000"
+          CODEX_REVIEW_POLL_MS: "5000"
+          CODEX_REVIEW_DEBOUNCE_MS: "5000"
+        run: |
+          set -euo pipefail
+          script_root="$GITHUB_WORKSPACE/.codex-review-trusted"
+          if [ ! -f "$script_root/scripts/codex-review-gate.mjs" ]; then
+            echo "::warning::Trusted Codex review gate is not on the default branch yet; using the bootstrap copy."
+            script_root="$GITHUB_WORKSPACE"
+            export CODEX_REVIEW_BOOTSTRAP=true
+          fi
+          node "$script_root/scripts/codex-review-gate.mjs"
+
+  dispatch-codex-review:
+    name: Codex Review dispatch
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Checkout proposed repository state
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.head_sha }}
+
+      - name: Checkout trusted Codex review gate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .codex-review-trusted
+          fetch-depth: 1
+
+      - name: Validate current-head Codex review
+        id: gate
+        continue-on-error: true
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CODEX_REVIEW_PR_NUMBER: ${{ inputs.pr_number }}
+          CODEX_REVIEW_HEAD_SHA: ${{ inputs.head_sha }}
+          CODEX_REVIEW_REQUIRE_HEAD_MATCH: "true"
+          CODEX_REVIEW_WAIT_MS: "30000"
+          CODEX_REVIEW_POLL_MS: "5000"
+          CODEX_REVIEW_DEBOUNCE_MS: "5000"
+        run: node "$GITHUB_WORKSPACE/.codex-review-trusted/scripts/codex-review-gate.mjs"
+
+      - name: Publish trusted result for the pull request head
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CODEX_REVIEW_HEAD_SHA: ${{ inputs.head_sha }}
+          CODEX_REVIEW_CONCLUSION: ${{ steps.gate.outcome == 'success' && 'success' || 'failure' }}
+          CODEX_REVIEW_DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node "$GITHUB_WORKSPACE/.codex-review-trusted/scripts/publish-codex-review-check.mjs"
+
+      - name: Fail the dispatch run when the gate fails
+        if: steps.gate.outcome != 'success'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ website/
 ```
 
 Root-level scripts provide repository policy, project-check orchestration,
-performance budgets, and dependency scanning. Codex reviews are requested on
-the current pull-request head and evaluated before merge; they are not exposed
-as a required status check because GitHub does not provide the native Codex
-review as an app-bound check run in this repository.
+performance budgets, and dependency scanning. Every pull request also goes
+through the required `Codex Review` gate: the check stays red until Codex has
+reviewed the current head. Request a review by commenting
+`@codex review <current-full-head-sha>` on the pull request; trusted
+default-branch orchestration binds the request and result to that exact
+40-character head SHA.
 
 ## Commands
 

--- a/scripts/check-repository.mjs
+++ b/scripts/check-repository.mjs
@@ -15,6 +15,20 @@ for (const path of [
   ".github/dependabot.yml",
   ".github/pull_request_template.md",
   ".github/workflows/ci.yml",
+  /* The current-head Codex review gate is a standing guardrail: the three
+     workflows and every script they run. Deleting a runtime script while its
+     workflow remains would merge under the old trusted gate and break every
+     later request, so all entrypoints are required here. The guardrail is
+     removed deliberately and separately, never by omission. */
+  ".github/workflows/codex-review.yml",
+  ".github/workflows/codex-review-request.yml",
+  ".github/workflows/codex-review-rerun.yml",
+  "scripts/codex-review-gate.mjs",
+  "scripts/codex-review-helpers.mjs",
+  "scripts/codex-review-request.mjs",
+  "scripts/codex-review-rerun.mjs",
+  "scripts/publish-codex-review-check.mjs",
+  "tests/codex-review-gate.test.mjs",
   ".gitignore",
   "AGENTS.md",
   "CLAUDE.md",

--- a/scripts/codex-review-gate.mjs
+++ b/scripts/codex-review-gate.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from "node:fs";
+import {
+  isAcceptableCodexSummaryComment,
+  isStrictlyAfterCodexReviewRequest,
+  latestCodexNativeReviewResult,
+  latestCodexReviewRequestMarker,
+  latestTrustedCodexReviewCommand
+} from "./codex-review-helpers.mjs";
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const prNumber = process.env.CODEX_REVIEW_PR_NUMBER;
+const eventHeadSha = process.env.CODEX_REVIEW_HEAD_SHA;
+const maxWaitMs = Number(process.env.CODEX_REVIEW_WAIT_MS || 30000);
+const pollMs = Number(process.env.CODEX_REVIEW_POLL_MS || 5000);
+const debounceMs = Number(process.env.CODEX_REVIEW_DEBOUNCE_MS || 5000);
+const bootstrap = process.env.CODEX_REVIEW_BOOTSTRAP === "true";
+const requireHeadMatch = process.env.CODEX_REVIEW_REQUIRE_HEAD_MATCH === "true";
+
+if (!token || !repository || !prNumber) {
+  console.error("GITHUB_TOKEN, GITHUB_REPOSITORY, and CODEX_REVIEW_PR_NUMBER are required.");
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split("/");
+
+async function request(path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28"
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function listPaginated(path) {
+  const items = [];
+  const separator = path.includes("?") ? "&" : "?";
+  for (let page = 1; ; page += 1) {
+    const batch = await request(`${path}${separator}per_page=100&page=${page}`);
+    items.push(...batch);
+    if (batch.length < 100) return items;
+  }
+}
+
+async function fetchPull() {
+  return request(`/repos/${owner}/${repo}/pulls/${prNumber}`);
+}
+
+const initialPull = await fetchPull();
+const headSha = eventHeadSha || initialPull.head?.sha;
+
+async function currentHeadMatches() {
+  const pull = await fetchPull();
+  return pull.head?.sha === headSha;
+}
+
+async function fetchEvidence() {
+  if (!await currentHeadMatches()) return "stale";
+
+  const comments = await listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/comments`);
+  let timeline = null;
+  let requestMarker = latestCodexReviewRequestMarker(comments, headSha);
+  if (!requestMarker && bootstrap) {
+    timeline = await listPaginated(`/repos/${owner}/${repo}/issues/${prNumber}/timeline`);
+    requestMarker = latestTrustedCodexReviewCommand(comments, timeline, headSha);
+  }
+  if (!requestMarker) return "missing_marker";
+
+  const [reviews, reviewComments] = await Promise.all([
+    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`),
+    listPaginated(`/repos/${owner}/${repo}/pulls/${prNumber}/comments`)
+  ]);
+  const reviewsAfterRequest = reviews.filter((review) =>
+    isStrictlyAfterCodexReviewRequest(review.submitted_at, requestMarker)
+  );
+  const nativeResult = latestCodexNativeReviewResult(
+    reviewsAfterRequest,
+    reviewComments,
+    headSha
+  );
+  if (nativeResult) return nativeResult;
+
+  return comments.some((comment) => isAcceptableCodexSummaryComment(
+    comment,
+    headSha,
+    requestMarker.sourceCommentCreatedAt || requestMarker.requestedAt || requestMarker.commentCreatedAt,
+    requestMarker.sourceCommentId
+  ))
+    ? "pass"
+    : "pending";
+}
+
+if (Number.isFinite(debounceMs) && debounceMs > 0) {
+  await new Promise((resolve) => setTimeout(resolve, debounceMs));
+}
+if (!await currentHeadMatches()) {
+  if (requireHeadMatch) {
+    console.error(`Codex Review failed: selected ref ${headSha} is not the current head of PR #${prNumber}.`);
+    process.exit(1);
+  }
+  console.log(`Codex Review skipped stale run for ${headSha}; PR head changed during debounce.`);
+  process.exit(0);
+}
+
+const started = Date.now();
+let outcome = "pending";
+let lastError = null;
+
+while (Date.now() - started <= maxWaitMs) {
+  try {
+    outcome = await fetchEvidence();
+    lastError = null;
+    if (["pass", "fail", "stale"].includes(outcome)) break;
+  } catch (error) {
+    lastError = error;
+  }
+
+  const remaining = maxWaitMs - (Date.now() - started);
+  if (remaining <= 0) break;
+  await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, remaining)));
+}
+
+if (outcome === "stale") {
+  console.log(`Codex Review skipped stale run for ${headSha}; PR head moved.`);
+  process.exit(0);
+}
+if (outcome === "pass") {
+  console.log(`Codex Review passed for ${headSha}.`);
+  process.exit(0);
+}
+
+const next = outcome === "missing_marker"
+  ? "A trusted OWNER, MEMBER, or COLLABORATOR must post '@codex review <current-full-head-sha>' on this PR."
+  : outcome === "fail"
+    ? "Resolve all P0-P2 findings, push fixes if needed, and request a new current-head review."
+    : "Wait for Codex evidence; its review event will rerun this gate automatically.";
+const summary = [
+  "## Codex Review gate failed",
+  "",
+  `- head SHA: \`${headSha}\``,
+  `- state: \`${outcome}\``,
+  `- next: ${next}`,
+  lastError ? `- API error: ${lastError.message}` : ""
+].filter(Boolean).join("\n");
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+}
+console.error(summary.replaceAll("`", ""));
+process.exit(1);

--- a/scripts/codex-review-helpers.mjs
+++ b/scripts/codex-review-helpers.mjs
@@ -1,0 +1,191 @@
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const CODEX_REVIEW_LOGIN = "chatgpt-codex-connector[bot]";
+
+function normalize(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function compareNumericIds(left, right) {
+  if (!/^\d+$/.test(String(left || "")) || !/^\d+$/.test(String(right || ""))) return 0;
+  const leftId = BigInt(left);
+  const rightId = BigInt(right);
+  return leftId === rightId ? 0 : leftId > rightId ? 1 : -1;
+}
+
+export function isStrictlyAfterCodexReviewRequest(value, requestMarker) {
+  const valueTime = Date.parse(value || "");
+  const requestedAt = Date.parse(
+    requestMarker?.sourceCommentCreatedAt ||
+    requestMarker?.requestedAt ||
+    requestMarker?.commentCreatedAt ||
+    ""
+  );
+  return Number.isFinite(valueTime) && Number.isFinite(requestedAt) && valueTime > requestedAt;
+}
+
+export function isTrustedAssociation(value) {
+  return TRUSTED_ASSOCIATIONS.has(String(value || "").toUpperCase());
+}
+
+export function isCodexReviewCommand(body) {
+  return /(?:^|\s)@codex\s+review\b/i.test(String(body || ""));
+}
+
+export function isCodexReviewCommandForHead(body, headSha) {
+  const requestedHead = String(body || "").match(
+    /(?:^|\s)@codex\s+review\s+`?([a-f0-9]{40})`?\b/i
+  )?.[1];
+  return Boolean(requestedHead) && normalize(requestedHead) === normalize(headSha);
+}
+
+export function isTrustedCodexLogin(login) {
+  return normalize(login) === CODEX_REVIEW_LOGIN;
+}
+
+export function createCodexReviewRequestMarkerBody({
+  headSha,
+  requestId,
+  sourceCommentId,
+  sourceCommentCreatedAt,
+  requestedAt
+}) {
+  const recordedAt = requestedAt || new Date().toISOString();
+  return [
+    `Codex review request recorded for \`${String(headSha || "").slice(0, 10)}\`.`,
+    "",
+    "<!-- web-design:codex-review-request",
+    `CODEX_REVIEW_REQUEST_ID: ${requestId}`,
+    `CODEX_REVIEW_SHA: ${headSha}`,
+    `CODEX_REVIEW_SOURCE_COMMENT_ID: ${sourceCommentId}`,
+    `CODEX_REVIEW_SOURCE_COMMENT_CREATED_AT: ${sourceCommentCreatedAt || recordedAt}`,
+    `CODEX_REVIEW_REQUESTED_AT: ${recordedAt}`,
+    "-->"
+  ].join("\n");
+}
+
+export function extractCodexReviewRequestMarker(body) {
+  const text = String(body || "");
+  if (!text.includes("web-design:codex-review-request")) return null;
+
+  const field = (name) =>
+    text.match(new RegExp(`^${name}:\\s*(.+?)\\s*$`, "im"))?.[1]?.trim() || null;
+  const requestId = field("CODEX_REVIEW_REQUEST_ID");
+  const sha = field("CODEX_REVIEW_SHA");
+  const sourceCommentId = field("CODEX_REVIEW_SOURCE_COMMENT_ID");
+  const sourceCommentCreatedAt = field("CODEX_REVIEW_SOURCE_COMMENT_CREATED_AT");
+  const requestedAt = field("CODEX_REVIEW_REQUESTED_AT");
+
+  if (!requestId || !sha || !sourceCommentId || !requestedAt) return null;
+  if (!/^[a-f0-9]{7,40}$/i.test(sha)) return null;
+
+  return {
+    requestId,
+    sha,
+    sourceCommentId,
+    sourceCommentCreatedAt,
+    requestedAt
+  };
+}
+
+export function latestCodexReviewRequestMarker(comments = [], headSha) {
+  return comments
+    .map((comment) => {
+      const marker = extractCodexReviewRequestMarker(comment?.body);
+      if (!marker) return null;
+      return {
+        ...marker,
+        commentId: String(comment.id || ""),
+        commentCreatedAt: comment.created_at || null,
+        author: normalize(comment.user?.login)
+      };
+    })
+    .filter((marker) =>
+      marker && marker.author === "github-actions[bot]" && marker.sha === headSha
+    )
+    .sort((left, right) => {
+      const byRequestTime = Date.parse(right.sourceCommentCreatedAt || right.requestedAt || "") -
+        Date.parse(left.sourceCommentCreatedAt || left.requestedAt || "");
+      return byRequestTime || compareNumericIds(right.sourceCommentId, left.sourceCommentId);
+    })[0] || null;
+}
+
+export function latestTrustedCodexReviewCommand(comments = [], timeline = [], headSha) {
+  return comments
+    .filter((comment) =>
+      comment?.user?.type !== "Bot" &&
+      isTrustedAssociation(comment?.author_association) &&
+      isCodexReviewCommandForHead(comment?.body, headSha)
+    )
+    .sort((left, right) =>
+      Date.parse(right.created_at || "") - Date.parse(left.created_at || "")
+    )
+    .map((comment) => ({
+      requestId: `bootstrap-${comment.id}-${String(headSha).slice(0, 12)}`,
+      sha: headSha,
+      sourceCommentId: String(comment.id || ""),
+      sourceCommentCreatedAt: comment.created_at,
+      requestedAt: comment.created_at,
+      commentCreatedAt: comment.created_at,
+      bootstrap: true
+    }))[0] || null;
+}
+
+export function extractCodexPriority(body) {
+  const match = String(body || "").match(/\bP([0-3])\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+export function containsBlockingCodexSeverity(body) {
+  const priority = extractCodexPriority(body);
+  return priority !== null && priority <= 2;
+}
+
+export function classifyCodexNativeReview(review, reviewComments = [], headSha) {
+  if (!review || review.commit_id !== headSha) return null;
+  if (!isTrustedCodexLogin(review.user?.login)) return null;
+  if (containsBlockingCodexSeverity(review.body)) return "fail";
+  if (review.state === "CHANGES_REQUESTED") return "fail";
+
+  const commentsForReview = reviewComments.filter((comment) =>
+    comment.pull_request_review_id === review.id &&
+    isTrustedCodexLogin(comment.user?.login)
+  );
+  if (commentsForReview.length > 0) {
+    const priorities = commentsForReview.map((comment) => extractCodexPriority(comment.body));
+    if (priorities.some((priority) => priority === null)) return "fail";
+    if (Math.min(...priorities) <= 2) return "fail";
+  }
+
+  return review.state === "APPROVED" || review.state === "COMMENTED" ? "pass" : null;
+}
+
+export function latestCodexNativeReviewResult(reviews = [], reviewComments = [], headSha) {
+  return reviews
+    .map((review) => ({
+      review,
+      result: classifyCodexNativeReview(review, reviewComments, headSha)
+    }))
+    .filter((entry) => entry.result !== null)
+    .sort((left, right) => {
+      const bySubmissionTime = Date.parse(right.review.submitted_at || "") -
+        Date.parse(left.review.submitted_at || "");
+      return bySubmissionTime || compareNumericIds(right.review.id, left.review.id);
+    })[0]?.result || null;
+}
+
+export function isAcceptableCodexSummaryComment(comment, headSha, requestedAt, sourceCommentId) {
+  const body = String(comment?.body || "");
+  const shortSha = String(headSha || "").slice(0, 10);
+  const commentCreatedAt = Date.parse(comment?.created_at || "");
+  const requestTime = Date.parse(requestedAt || "");
+  const ordering = commentCreatedAt === requestTime
+    ? compareNumericIds(comment?.id, sourceCommentId) > 0
+    : commentCreatedAt > requestTime;
+  const isAfterRequest = !requestedAt ||
+    (Number.isFinite(commentCreatedAt) && Number.isFinite(requestTime) && ordering);
+  return isAfterRequest &&
+    isTrustedCodexLogin(comment?.user?.login) &&
+    /^Codex Review:\s*Didn't find any major issues\./im.test(body) &&
+    Boolean(shortSha) &&
+    new RegExp(`\\*\\*Reviewed commit:\\*\\*\\s*\\\`${shortSha}\\\``, "i").test(body);
+}

--- a/scripts/codex-review-request.mjs
+++ b/scripts/codex-review-request.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  createCodexReviewRequestMarkerBody,
+  isCodexReviewCommand,
+  isCodexReviewCommandForHead,
+  isTrustedAssociation
+} from "./codex-review-helpers.mjs";
+import { rerunCodexReviewForHead } from "./codex-review-rerun.mjs";
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!token || !repository || !eventPath) {
+    throw new Error("GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_EVENT_PATH are required.");
+  }
+
+  const [owner, repo] = repository.split("/");
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const comment = event.comment;
+  if (!event.issue?.pull_request || !comment || !isCodexReviewCommand(comment.body)) {
+    throw new Error("The request must be an @codex review comment on a pull request.");
+  }
+  if (comment.user?.type === "Bot" || !isTrustedAssociation(comment.author_association)) {
+    throw new Error("Only OWNER, MEMBER, or COLLABORATOR comments can request Codex review.");
+  }
+
+  async function request(path, options = {}) {
+    const response = await fetch(`https://api.github.com${path}`, {
+      ...options,
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/vnd.github+json",
+        "x-github-api-version": "2022-11-28",
+        ...(options.headers || {})
+      }
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}: ${text}`);
+    }
+    return text ? JSON.parse(text) : null;
+  }
+
+  const pull = await request(`/repos/${owner}/${repo}/pulls/${event.issue.number}`);
+  const headSha = pull.head?.sha;
+  if (!isCodexReviewCommandForHead(comment.body, headSha)) {
+    throw new Error("The @codex review command must include the current full PR head SHA.");
+  }
+  const requestedAt = comment.created_at || new Date().toISOString();
+  const markerBody = createCodexReviewRequestMarkerBody({
+    headSha,
+    requestId: `${comment.id}-${String(headSha).slice(0, 12)}`,
+    sourceCommentId: String(comment.id),
+    sourceCommentCreatedAt: comment.created_at,
+    requestedAt
+  });
+
+  await request(`/repos/${owner}/${repo}/issues/${event.issue.number}/comments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ body: markerBody })
+  });
+
+  try {
+    const result = await rerunCodexReviewForHead({ token, repository, headSha });
+    console.log(result.message);
+  } catch (error) {
+    console.warn(`Marker recorded, but Codex Review rerun could not be requested: ${error.message}`);
+  }
+
+  console.log(`Trusted Codex review request recorded for ${headSha}.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`Codex review request rejected: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/codex-review-rerun.mjs
+++ b/scripts/codex-review-rerun.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isTrustedCodexLogin } from "./codex-review-helpers.mjs";
+
+const ACTIVE_STATUSES = new Set([
+  "queued",
+  "in_progress",
+  "waiting",
+  "requested",
+  "pending"
+]);
+const ACTIVE_RUN_POLL_INTERVAL_MS = 10_000;
+const MAX_ACTIVE_RUN_POLLS = 24;
+
+export function shouldRouteCodexReviewRerunEvent(event) {
+  if (event?.review) return isTrustedCodexLogin(event.review.user?.login);
+  if (!event?.issue?.pull_request || !event?.comment) return false;
+  return /^Codex Review:/i.test(String(event.comment.body || "")) &&
+    isTrustedCodexLogin(event.comment.user?.login);
+}
+
+export function selectCodexReviewRun(runs = [], headSha) {
+  const matchingRuns = runs
+    .filter((run) => run.event === "pull_request" && run.head_sha === headSha)
+    .sort((left, right) =>
+      Date.parse(right.created_at || "") - Date.parse(left.created_at || "")
+    );
+
+  const activeRun = matchingRuns.find((run) => ACTIVE_STATUSES.has(run.status));
+  if (activeRun) return { action: "wait_for_active_then_rerun", run: activeRun };
+
+  const rerunnableRun = matchingRuns.find((run) => run.status === "completed");
+  if (rerunnableRun) return { action: "rerun", run: rerunnableRun };
+
+  return { action: "not_found", run: null };
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function defaultRequest(token, repository, path, options = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+      ...(options.headers || {})
+    }
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${text}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+export async function rerunCodexReviewForHead({
+  token,
+  repository,
+  headSha,
+  request = defaultRequest,
+  sleep = defaultSleep,
+  maxActiveRunPolls = MAX_ACTIVE_RUN_POLLS
+}) {
+  if (!token || !repository || !headSha) {
+    throw new Error("token, repository, and headSha are required to rerun Codex Review.");
+  }
+
+  const [owner, repo] = repository.split("/");
+  const runsPath = `/repos/${owner}/${repo}/actions/workflows/codex-review.yml/runs?event=pull_request&head_sha=${encodeURIComponent(headSha)}&per_page=100`;
+  let data = await request(token, repository, runsPath);
+  let selected = selectCodexReviewRun(data.workflow_runs || [], headSha);
+
+  for (let poll = 0; selected.action === "wait_for_active_then_rerun" && poll < maxActiveRunPolls; poll += 1) {
+    await sleep(ACTIVE_RUN_POLL_INTERVAL_MS);
+    data = await request(token, repository, runsPath);
+    selected = selectCodexReviewRun(data.workflow_runs || [], headSha);
+  }
+
+  if (selected.action === "wait_for_active_then_rerun") {
+    throw new Error(
+      `Codex Review run ${selected.run.id} remained active while waiting to evaluate new trusted evidence for ${headSha}.`
+    );
+  }
+
+  if (selected.action === "rerun") {
+    await request(
+      token,
+      repository,
+      `/repos/${owner}/${repo}/actions/runs/${selected.run.id}/rerun`,
+      { method: "POST" }
+    );
+    return {
+      ...selected,
+      message: `Requested Codex Review rerun for ${headSha} from run ${selected.run.id}.`
+    };
+  }
+
+  const runId = selected.run?.id ? ` run ${selected.run.id}` : "";
+  const messages = {
+    not_found: `No completed Codex Review pull_request run found for ${headSha}.`
+  };
+  return { ...selected, message: messages[selected.action] };
+}
+
+async function resolveHeadSha({ token, repository, event, request = defaultRequest }) {
+  if (event?.pull_request?.head?.sha) return event.pull_request.head.sha;
+  if (!event?.issue?.pull_request || !event?.issue?.number) {
+    throw new Error("Could not resolve pull request from event.");
+  }
+  const [owner, repo] = repository.split("/");
+  const pull = await request(
+    token,
+    repository,
+    `/repos/${owner}/${repo}/pulls/${event.issue.number}`
+  );
+  return pull.head?.sha;
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!token || !repository || !eventPath) {
+    throw new Error("GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_EVENT_PATH are required.");
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  if (!shouldRouteCodexReviewRerunEvent(event)) {
+    console.log("Codex Review rerun skipped: event is not trusted Codex evidence.");
+    return;
+  }
+
+  const headSha = await resolveHeadSha({ token, repository, event });
+  const result = await rerunCodexReviewForHead({ token, repository, headSha });
+  console.log(result.message);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`Codex Review rerun failed: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/publish-codex-review-check.mjs
+++ b/scripts/publish-codex-review-check.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const headSha = process.env.CODEX_REVIEW_HEAD_SHA;
+const conclusion = process.env.CODEX_REVIEW_CONCLUSION;
+const detailsUrl = process.env.CODEX_REVIEW_DETAILS_URL;
+
+export function checkRunPayload({ headSha, conclusion, detailsUrl }) {
+  if (!/^[a-f0-9]{40}$/i.test(String(headSha || ""))) {
+    throw new Error("CODEX_REVIEW_HEAD_SHA must be a full 40-character commit SHA.");
+  }
+  if (!new Set(["success", "failure"]).has(conclusion)) {
+    throw new Error("CODEX_REVIEW_CONCLUSION must be success or failure.");
+  }
+  if (!/^https:\/\//.test(String(detailsUrl || ""))) {
+    throw new Error("CODEX_REVIEW_DETAILS_URL must be an HTTPS URL.");
+  }
+
+  const passed = conclusion === "success";
+  return {
+    name: "Codex Review",
+    head_sha: headSha,
+    status: "completed",
+    conclusion,
+    details_url: detailsUrl,
+    output: {
+      title: passed ? "Codex Review passed" : "Codex Review failed",
+      summary: passed
+        ? `Trusted manual validation passed for ${headSha}.`
+        : `Trusted manual validation failed for ${headSha}. See the workflow logs for the blocking evidence.`
+    }
+  };
+}
+
+export async function publishCodexReviewCheck({
+  token,
+  repository,
+  headSha,
+  conclusion,
+  detailsUrl,
+  request = globalThis.fetch
+}) {
+  if (!token || !repository) {
+    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required.");
+  }
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) throw new Error("GITHUB_REPOSITORY must be owner/repo.");
+
+  const response = await request(`https://api.github.com/repos/${owner}/${repo}/check-runs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28"
+    },
+    body: JSON.stringify(checkRunPayload({ headSha, conclusion, detailsUrl }))
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  try {
+    await publishCodexReviewCheck({ token, repository, headSha, conclusion, detailsUrl });
+    console.log(`Published Codex Review ${conclusion} result for ${headSha}.`);
+  } catch (error) {
+    console.error(`Could not publish Codex Review check: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/tests/codex-review-gate.test.mjs
+++ b/tests/codex-review-gate.test.mjs
@@ -1,0 +1,424 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repositoryRoot = resolve(
+  process.env.WEB_DESIGN_REPOSITORY_ROOT || resolve(import.meta.dirname, "..")
+);
+const helpers = await import(pathToFileURL(
+  resolve(repositoryRoot, "scripts/codex-review-helpers.mjs")
+).href);
+const rerun = await import(pathToFileURL(
+  resolve(repositoryRoot, "scripts/codex-review-rerun.mjs")
+).href);
+const publisher = await import(pathToFileURL(
+  resolve(repositoryRoot, "scripts/publish-codex-review-check.mjs")
+).href);
+
+const {
+  classifyCodexNativeReview,
+  createCodexReviewRequestMarkerBody,
+  extractCodexReviewRequestMarker,
+  isAcceptableCodexSummaryComment,
+  isCodexReviewCommand,
+  isCodexReviewCommandForHead,
+  isStrictlyAfterCodexReviewRequest,
+  isTrustedAssociation,
+  latestCodexNativeReviewResult,
+  latestCodexReviewRequestMarker,
+  latestTrustedCodexReviewCommand
+} = helpers;
+const {
+  rerunCodexReviewForHead,
+  selectCodexReviewRun,
+  shouldRouteCodexReviewRerunEvent
+} = rerun;
+const { checkRunPayload, publishCodexReviewCheck } = publisher;
+
+const headSha = "abc123def456";
+const codexUser = { login: "chatgpt-codex-connector[bot]" };
+
+function markerBody() {
+  return createCodexReviewRequestMarkerBody({
+    headSha,
+    requestId: "10-abc123def456",
+    sourceCommentId: "10",
+    sourceCommentCreatedAt: "2026-08-05T12:00:00Z",
+    requestedAt: "2026-08-05T12:00:00Z"
+  });
+}
+
+test("trusted request associations and the Codex command are explicit", () => {
+  const commandHeadSha = "abcdef0123456789abcdef0123456789abcdef01";
+  assert.equal(isTrustedAssociation("OWNER"), true);
+  assert.equal(isTrustedAssociation("MEMBER"), true);
+  assert.equal(isTrustedAssociation("COLLABORATOR"), true);
+  assert.equal(isTrustedAssociation("CONTRIBUTOR"), false);
+  assert.equal(isCodexReviewCommand("@codex review"), true);
+  assert.equal(isCodexReviewCommand("please @CoDeX   review this"), true);
+  assert.equal(isCodexReviewCommand("@codex implement"), false);
+  assert.equal(isCodexReviewCommandForHead(`@codex review ${commandHeadSha}`, commandHeadSha), true);
+  assert.equal(isCodexReviewCommandForHead(`@codex review ${commandHeadSha}`, "b".repeat(40)), false);
+  assert.equal(isCodexReviewCommandForHead("@codex review", commandHeadSha), false);
+});
+
+test("request markers bind a GitHub Actions comment to the current head", () => {
+  assert.deepEqual(extractCodexReviewRequestMarker(markerBody()), {
+    requestId: "10-abc123def456",
+    sha: headSha,
+    sourceCommentId: "10",
+    sourceCommentCreatedAt: "2026-08-05T12:00:00Z",
+    requestedAt: "2026-08-05T12:00:00Z"
+  });
+
+  const trusted = {
+    id: 11,
+    body: markerBody(),
+    created_at: "2026-08-05T12:00:01Z",
+    user: { login: "github-actions[bot]" }
+  };
+  assert.equal(latestCodexReviewRequestMarker([trusted], headSha)?.requestId, "10-abc123def456");
+  assert.equal(
+    latestCodexReviewRequestMarker([{ ...trusted, user: { login: "repo-owner" } }], headSha),
+    null,
+    "a user-authored forged marker must not be accepted"
+  );
+  assert.equal(latestCodexReviewRequestMarker([trusted], "new-head"), null);
+  const olderRequestPublishedLater = {
+    ...trusted,
+    body: createCodexReviewRequestMarkerBody({
+      headSha,
+      requestId: "20-abc123def456",
+      sourceCommentId: "20",
+      sourceCommentCreatedAt: "2026-08-05T12:00:00Z",
+      requestedAt: "2026-08-05T12:00:00Z"
+    }),
+    created_at: "2026-08-05T12:00:02Z"
+  };
+  const laterRequestPublishedFirst = {
+    ...trusted,
+    body: createCodexReviewRequestMarkerBody({
+      headSha,
+      requestId: "21-abc123def456",
+      sourceCommentId: "21",
+      sourceCommentCreatedAt: "2026-08-05T12:00:01Z",
+      requestedAt: "2026-08-05T12:00:01Z"
+    }),
+    created_at: "2026-08-05T12:00:01Z"
+  };
+  assert.equal(
+    latestCodexReviewRequestMarker([olderRequestPublishedLater, laterRequestPublishedFirst], headSha)?.sourceCommentId,
+    "21",
+    "markers are ordered by their source request, not delayed marker publication"
+  );
+});
+
+test("the installation PR can bind directly to a trusted request comment", () => {
+  const installationHeadSha = "abcdef0123456789abcdef0123456789abcdef01";
+  const command = {
+    id: 12,
+    body: `@codex review ${installationHeadSha}`,
+    created_at: "2026-08-05T12:00:00Z",
+    author_association: "OWNER",
+    user: { login: "repo-owner", type: "User" }
+  };
+  assert.equal(
+    latestTrustedCodexReviewCommand([command], [], installationHeadSha)?.bootstrap,
+    true
+  );
+  assert.equal(
+    latestTrustedCodexReviewCommand(
+      [command],
+      [{ event: "committed", created_at: "2026-08-05T12:01:00Z" }],
+      "new-head"
+    ),
+    null,
+    "a later head update changes the required command SHA"
+  );
+  assert.equal(
+    latestTrustedCodexReviewCommand(
+      [{ ...command, author_association: "CONTRIBUTOR" }],
+      [],
+      installationHeadSha
+    ),
+    null
+  );
+});
+
+test("native Codex reviews are current-head and P0-P2 blocking", () => {
+  const review = {
+    id: 20,
+    commit_id: headSha,
+    state: "COMMENTED",
+    submitted_at: "2026-08-05T12:01:00Z",
+    user: codexUser
+  };
+
+  assert.equal(classifyCodexNativeReview(review, [], headSha), "pass");
+  assert.equal(classifyCodexNativeReview(review, [{
+    pull_request_review_id: 20,
+    body: "![P3 Badge] Advisory note",
+    user: codexUser
+  }], headSha), "pass");
+  assert.equal(classifyCodexNativeReview(review, [{
+    pull_request_review_id: 20,
+    body: "![P2 Badge] Blocking issue",
+    user: codexUser
+  }], headSha), "fail");
+  assert.equal(classifyCodexNativeReview({
+    ...review,
+    state: "APPROVED"
+  }, [{
+    pull_request_review_id: 20,
+    body: "![P2 Badge] Blocking issue",
+    user: codexUser
+  }], headSha), "fail", "approved reviews must still inspect inline findings");
+  assert.equal(classifyCodexNativeReview(review, [{
+    pull_request_review_id: 20,
+    body: "Unclassified finding",
+    user: codexUser
+  }], headSha), "fail");
+  assert.equal(classifyCodexNativeReview(review, [], "new-head"), null);
+  assert.equal(
+    classifyCodexNativeReview({ ...review, user: { login: "fake-codex[bot]" } }, [], headSha),
+    null
+  );
+});
+
+test("manual trusted validation publishes a head-bound check result", async () => {
+  const requests = [];
+  const request = async (url, options) => {
+    requests.push({ url, options });
+    return { ok: true, json: async () => ({ id: 1 }) };
+  };
+  await publishCodexReviewCheck({
+    token: "token",
+    repository: "owner/repo",
+    headSha: "a".repeat(40),
+    conclusion: "success",
+    detailsUrl: "https://github.com/owner/repo/actions/runs/1",
+    request
+  });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "https://api.github.com/repos/owner/repo/check-runs");
+  assert.equal(requests[0].options.method, "POST");
+  assert.deepEqual(JSON.parse(requests[0].options.body), {
+    name: "Codex Review",
+    head_sha: "a".repeat(40),
+    status: "completed",
+    conclusion: "success",
+    details_url: "https://github.com/owner/repo/actions/runs/1",
+    output: {
+      title: "Codex Review passed",
+      summary: `Trusted manual validation passed for ${"a".repeat(40)}.`
+    }
+  });
+  assert.throws(
+    () => checkRunPayload({ headSha: "short", conclusion: "success", detailsUrl: "https://example.com" }),
+    /40-character commit SHA/
+  );
+  assert.throws(
+    () => checkRunPayload({ headSha: "a".repeat(40), conclusion: "neutral", detailsUrl: "https://example.com" }),
+    /success or failure/
+  );
+});
+
+test("native reviews require a strictly later request timestamp", () => {
+  const request = { sourceCommentCreatedAt: "2026-08-05T12:00:00Z" };
+  assert.equal(isStrictlyAfterCodexReviewRequest("2026-08-05T12:00:01Z", request), true);
+  assert.equal(
+    isStrictlyAfterCodexReviewRequest("2026-08-05T12:00:00Z", request),
+    false,
+    "same-second reviews cannot be attributed unambiguously to the latest request"
+  );
+});
+
+test("Codex no-findings summaries must name the reviewed head", () => {
+  const summary = {
+    body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${headSha.slice(0, 10)}\``,
+    created_at: "2026-08-05T12:01:00Z",
+    id: "31",
+    user: codexUser
+  };
+  assert.equal(isAcceptableCodexSummaryComment(summary, headSha), true);
+  assert.equal(
+    isAcceptableCodexSummaryComment(summary, headSha, "2026-08-05T12:00:00Z"),
+    true,
+    "a current-head summary posted after the request is acceptable"
+  );
+  assert.equal(
+    isAcceptableCodexSummaryComment(summary, headSha, "2026-08-05T12:02:00Z"),
+    false,
+    "an older summary cannot satisfy a newer review request"
+  );
+  assert.equal(
+    isAcceptableCodexSummaryComment(summary, headSha, "2026-08-05T12:01:00Z", "30"),
+    true,
+    "a same-second summary posted after the request is acceptable"
+  );
+  assert.equal(
+    isAcceptableCodexSummaryComment(summary, headSha, "2026-08-05T12:01:00Z", "32"),
+    false,
+    "a same-second summary posted before the request is rejected"
+  );
+  assert.equal(isAcceptableCodexSummaryComment({ ...summary, body: "Codex Review: Didn't find any major issues." }, headSha), false);
+  assert.equal(isAcceptableCodexSummaryComment({ ...summary, body: summary.body.replace(headSha.slice(0, 10), "0000000000") }, headSha), false);
+});
+
+test("the latest current-head native Codex result wins", () => {
+  const olderPass = {
+    id: 1,
+    commit_id: headSha,
+    state: "COMMENTED",
+    submitted_at: "2026-08-05T12:01:00Z",
+    user: codexUser
+  };
+  const newerFail = {
+    ...olderPass,
+    id: 2,
+    submitted_at: "2026-08-05T12:02:00Z"
+  };
+  assert.equal(latestCodexNativeReviewResult([olderPass, newerFail], [{
+    pull_request_review_id: 2,
+    body: "P1 regression",
+    user: codexUser
+  }], headSha), "fail");
+  assert.equal(
+    latestCodexNativeReviewResult([
+      { ...olderPass, submitted_at: "2026-08-05T12:03:00Z" },
+      { ...newerFail, submitted_at: "2026-08-05T12:03:00Z" }
+    ], [{
+      pull_request_review_id: 2,
+      body: "P1 regression",
+      user: codexUser
+    }], headSha),
+    "fail",
+    "a higher native review ID wins a same-second tie"
+  );
+});
+
+test("rerun routing accepts only exact trusted Codex evidence", () => {
+  assert.equal(shouldRouteCodexReviewRerunEvent({ review: { user: codexUser } }), true);
+  assert.equal(
+    shouldRouteCodexReviewRerunEvent({
+      issue: { pull_request: {} },
+      comment: { body: "Codex Review: Didn't find any major issues.", user: codexUser }
+    }),
+    true
+  );
+  assert.equal(
+    shouldRouteCodexReviewRerunEvent({ review: { user: { login: "fake-codex[bot]" } } }),
+    false
+  );
+});
+
+test("rerun selection is head-bound and waits for active runs before rerunning", () => {
+  const failed = {
+    id: 30,
+    event: "pull_request",
+    head_sha: headSha,
+    status: "completed",
+    conclusion: "failure",
+    created_at: "2026-08-05T12:00:00Z"
+  };
+  assert.deepEqual(selectCodexReviewRun([failed], headSha), { action: "rerun", run: failed });
+  const succeeded = { ...failed, conclusion: "success" };
+  assert.deepEqual(
+    selectCodexReviewRun([succeeded], headSha),
+    { action: "rerun", run: succeeded },
+    "fresh trusted evidence must re-evaluate a previously successful gate run"
+  );
+  const active = {
+    ...failed,
+    id: 31,
+    status: "in_progress",
+    conclusion: null,
+    created_at: "2026-08-05T12:01:00Z"
+  };
+  assert.deepEqual(
+    selectCodexReviewRun([failed, active], headSha),
+    { action: "wait_for_active_then_rerun", run: active }
+  );
+  assert.deepEqual(selectCodexReviewRun([failed], "new-head"), {
+    action: "not_found",
+    run: null
+  });
+});
+
+test("rerun helper waits for an active gate before rerunning it", async () => {
+  const calls = [];
+  const active = {
+    id: 42,
+    event: "pull_request",
+    head_sha: headSha,
+    status: "in_progress",
+    conclusion: null,
+    created_at: "2026-08-05T12:00:00Z"
+  };
+  let readCount = 0;
+  const request = async (_token, _repository, path, options = {}) => {
+    calls.push({ path, method: options.method || "GET" });
+    if (path.includes("/actions/workflows/codex-review.yml/runs")) {
+      readCount += 1;
+      return {
+        workflow_runs: [readCount === 1 ? active : {
+          ...active,
+          status: "completed",
+          conclusion: "success"
+        }]
+      };
+    }
+    return null;
+  };
+
+  const result = await rerunCodexReviewForHead({
+    token: "token",
+    repository: "owner/repo",
+    headSha,
+    request,
+    sleep: async () => {}
+  });
+
+  assert.equal(result.action, "rerun");
+  assert.equal(calls.filter(({ method }) => method === "GET").length, 2);
+  assert.deepEqual(calls.at(-1), {
+    path: "/repos/owner/repo/actions/runs/42/rerun",
+    method: "POST"
+  });
+});
+
+test("rerun helper calls the Actions endpoint for a failed head-bound run", async () => {
+  const calls = [];
+  const request = async (_token, _repository, path, options = {}) => {
+    calls.push({ path, method: options.method || "GET" });
+    if (path.includes("/actions/workflows/codex-review.yml/runs")) {
+      return {
+        workflow_runs: [{
+          id: 42,
+          event: "pull_request",
+          head_sha: headSha,
+          status: "completed",
+          conclusion: "failure",
+          created_at: "2026-08-05T12:00:00Z"
+        }]
+      };
+    }
+    return null;
+  };
+
+  const result = await rerunCodexReviewForHead({
+    token: "token",
+    repository: "owner/repo",
+    headSha,
+    request
+  });
+  assert.equal(result.action, "rerun");
+  assert.deepEqual(calls, [
+    {
+      path: `/repos/owner/repo/actions/workflows/codex-review.yml/runs?event=pull_request&head_sha=${headSha}&per_page=100`,
+      method: "GET"
+    },
+    { path: "/repos/owner/repo/actions/runs/42/rerun", method: "POST" }
+  ]);
+});

--- a/tests/harness.test.mjs
+++ b/tests/harness.test.mjs
@@ -208,6 +208,15 @@ test("the dependency update policy and language rules are required", () => {
   });
 });
 
+test("the current-head Codex review gate is a required guardrail", () => {
+  withFixture({}, (root) => {
+    rmSync(join(root, "scripts/codex-review-gate.mjs"));
+    const result = run(root, "check-repository.mjs");
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Missing harness file: scripts\/codex-review-gate\.mjs/);
+  });
+});
+
 test("dependabot groups minor and patch updates behind a cooldown", () => {
   const [, actions, npm, ...extra] = readFileSync(join(templateRoot, ".github/dependabot.yml"), "utf8")
     .split(/^\s*- package-ecosystem:/m);


### PR DESCRIPTION
## Summary

- restore the canonical `web-design` Codex review workflows and trusted current-head orchestration
- bind review requests and results to the full PR head SHA, with P0–P2 findings blocking
- make every gate workflow, runtime script, and regression test part of the repository guard
- keep the existing standard Dependabot policy; verified GitHub Actions and `/website` weekly updates, cooldowns, and grouped minor/patch updates

## Safety and validation

- [x] `npm run preflight`
- [x] 27 harness/gate tests passed
- [x] 6 website tests passed
- [x] payload budget passed: 451,841 B raw / 408,732 B gzip; 20,920 B critical gzip
- [x] GitHub reports Dependabot security updates enabled and not paused

## Rollout

After opening this PR, add the app-bound `Codex Review` context to `main` branch protection. The installation workflow includes the canonical bootstrap path so this PR can satisfy the new gate before the scripts reach `main`.

Co-authored-by: Codex <codex@openai.com>