### PR TITLE
fix: soft water washes, edge-to-edge phone canvas, livelier pace on small screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ that follows the visitor's local time of day.
   the study on a rounded midnight tile — head to the right, veil fins, a warm
   glow — drawn as vector paths and shipped inline; it replaces the plain gold
   disc.
+- Design assumptions (2026-09-06, awaiting Kristina's review on the stage
+  preview): the water's brush marks are soft washes instead of hard-edged
+  bars; on small screens the school's pace is lifted (up to 2.2×) towards
+  the desktop feel; on iPhones the canvas runs under Safari's bottom bar and
+  the status bar is tinted to the water. See "The artwork" below.
 - Implemented in `website/src/index.html` with the three fish files beside it.
   The approved canonical domain is
   `fathom.ks-design.art`; Cloudflare deploys `main` to production and creates
@@ -41,20 +46,39 @@ that follows the visitor's local time of day.
   automatically if the pictures fail to load or do not arrive within eight
   seconds (whatever has loaded by then is used).
 - **Water.** A brushed, vertically streaked ground, light shafts from above,
-  drifting caustics and motes. At night the fish gain a warm glow.
+  drifting caustics and motes. At night the fish gain a warm glow. The brush
+  marks are soft washes: tapered marks painted on two coarse sheets (quarter
+  and half scale) and laid onto the ground blurred, so they read as paint;
+  drawn as hard-edged bars they overlapped into fine stripes and blocks that
+  looked like interference (fixed 2026-09-06).
 - **Time of day.** The page reads the visitor's clock: day 07:00–16:30, dusk
   16:30–20:30 and 05:30–07:00, midnight otherwise. It re-checks every 20 s and
   cross-fades palette, ground and effects over six seconds when the mood
   changes. The bottom controls pin a mood (`auto` returns to the clock);
   `?mood=day|dusk|midnight` in the URL pins it for screenshots and reviews,
   and `?motion=reduce` forces the still frame for review.
+- **Pace and screen.** Fish sizes and speeds follow the short side of the
+  canvas, so a phone would show a school a quarter the size drifting at a
+  quarter of the pixels per second; a pace factor lifts small screens back
+  towards the desktop feel: 1 at a 1000 px short side, about 1.2 on a 746 px
+  laptop window, about 1.9 on a 390 px phone, 2.2 at most. Fixed-viewport
+  browsers on phones leave strips of flat colour above and below the page;
+  the page opts into the full screen (`viewport-fit=cover`) with the
+  wordmark, controls and credit kept inside the safe area, and on iPhones in
+  portrait the canvas takes the large viewport height so the water is
+  painted on under Safari's translucent bottom bar. Safari never lets a page
+  paint its status bar, so that strip is tinted instead: `theme-color` (and
+  the canvas's own background colour, which iOS 26 samples) follow the mean
+  colour of the water's top edge through every mood and fade. A resize
+  event that changes nothing (iPhone Safari sends them on tab switches and
+  bar toggles) leaves the scene alone.
 - **Motion and access.** Under `prefers-reduced-motion: reduce` the scene
   renders a single still frame (the mood controls still work, re-rendering
   once). The canvas is decorative (`aria-hidden`); the mood carries no visible
   caption (client decision, 2026-09-04) but is still announced through a
   visually hidden `role="status"` region; the controls are native buttons in a
   labelled group, each carrying `aria-pressed`.
-- **Budget.** One HTML file (about 60 KB raw) plus three WebP fish
+- **Budget.** One HTML file (about 65 KB raw) plus three WebP fish
   (about 110–160 KB each, alpha included; about 400 KB in total); no fonts,
   scripts or requests beyond these same-origin files. The footer credit is
   the only outward link.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ that follows the visitor's local time of day.
   disc.
 - Design assumptions (2026-09-06, awaiting Kristina's review on the stage
   preview): the water's brush marks are soft washes instead of hard-edged
-  bars; on small screens the school's pace is lifted (up to 2.2×) towards
-  the desktop feel; on iPhones the canvas runs under Safari's bottom bar and
+  bars; on small screens the school's pace is lifted (up to 1.6×, halfway
+  between the original crawl and a first cut at 2.2× that read as too quick
+  on the phone); on iPhones the canvas runs under Safari's bottom bar and
   the status bar is tinted to the water. See "The artwork" below.
 - Implemented in `website/src/index.html` with the three fish files beside it.
   The approved canonical domain is
@@ -50,7 +51,13 @@ that follows the visitor's local time of day.
   marks are soft washes: tapered marks painted on two coarse sheets (quarter
   and half scale) and laid onto the ground blurred, so they read as paint;
   drawn as hard-edged bars they overlapped into fine stripes and blocks that
-  looked like interference (fixed 2026-09-06).
+  looked like interference (fixed 2026-09-06). Two more hairline sources
+  are closed the same week: every fish is warped on one shared scratch
+  canvas, and a bilinear blit reads one texel past its source rectangle, so
+  a smaller fish carried a bright hairline of the previous, larger sprite
+  (its glow, at midnight) along its right and bottom edges — the margin is
+  now cleared too; and the caustic tiles are built at device resolution and
+  scrolled by whole device pixels, so their repeat edge is never resampled.
 - **Time of day.** The page reads the visitor's clock: day 07:00–16:30, dusk
   16:30–20:30 and 05:30–07:00, midnight otherwise. It re-checks every 20 s and
   cross-fades palette, ground and effects over six seconds when the mood
@@ -60,18 +67,23 @@ that follows the visitor's local time of day.
 - **Pace and screen.** Fish sizes and speeds follow the short side of the
   canvas, so a phone would show a school a quarter the size drifting at a
   quarter of the pixels per second; a pace factor lifts small screens back
-  towards the desktop feel: 1 at a 1000 px short side, about 1.2 on a 746 px
-  laptop window, about 1.9 on a 390 px phone, 2.2 at most. Fixed-viewport
+  part of the way back towards the desktop feel: 1 at a 1000 px short side,
+  about 1.12 on a 746 px laptop window, about 1.45 on a 390 px phone, 1.6 at
+  most. Fixed-viewport
   browsers on phones leave strips of flat colour above and below the page;
   the page opts into the full screen (`viewport-fit=cover`) with the
-  wordmark, controls and credit kept inside the safe area, and on iPhones in
-  portrait the canvas takes the large viewport height so the water is
-  painted on under Safari's translucent bottom bar. Safari never lets a page
-  paint its status bar, so that strip is tinted instead: `theme-color` (and
-  the canvas's own background colour, which iOS 26 samples) follow the mean
-  colour of the water's top edge through every mood and fade. A resize
-  event that changes nothing (iPhone Safari sends them on tab switches and
-  bar toggles) leaves the scene alone.
+  wordmark, controls and credit kept inside the safe area. On iPhones in
+  portrait the canvas is laid out as document content, 120 px taller than
+  the large viewport, so the document runs on through the zone of Safari's
+  bottom bar and the water shows in the bar's glass (Safari clips the page
+  at the document's bottom inside that zone, so a taller *fixed* canvas was
+  cut at the bar's edge and the bar showed Safari's own flat fill). Safari
+  never lets a page paint its status bar, so that strip is tinted instead:
+  `theme-color` (iOS 15–18) and a fixed 8 px strip at the page's top edge
+  (iOS 26 samples the fixed element it finds there and ignores
+  `theme-color`) follow the mean colour of the water's top edge through
+  every mood and fade. A resize event that changes nothing (iPhone Safari
+  sends them on tab switches and bar toggles) leaves the scene alone.
 - **Motion and access.** Under `prefers-reduced-motion: reduce` the scene
   renders a single still frame (the mood controls still work, re-rendering
   once). The canvas is decorative (`aria-hidden`); the mood carries no visible

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ that follows the visitor's local time of day.
   the study on a rounded midnight tile — head to the right, veil fins, a warm
   glow — drawn as vector paths and shipped inline; it replaces the plain gold
   disc.
-- Design assumptions (2026-09-06, awaiting Kristina's review on the stage
-  preview): the water's brush marks are soft washes instead of hard-edged
-  bars; on small screens the school's pace is lifted (up to 1.6×, halfway
-  between the original crawl and a first cut at 2.2× that read as too quick
-  on the phone); on iPhones the canvas runs under Safari's bottom bar and
-  the status bar is tinted to the water. See "The artwork" below.
+- Client decision (Kristina, 2026-09-07, approved on the stage preview from
+  her iPhone and desktop): the water's brush marks are soft washes instead
+  of hard-edged bars; on small screens the school's pace is lifted up to
+  1.6× (halfway between the original crawl and a first cut at 2.2× that read
+  as too quick on the phone); on iPhones the water runs on under Safari's
+  bottom bar while the status bar is tinted to the water. See "The artwork"
+  below.
 - Implemented in `website/src/index.html` with the three fish files beside it.
   The approved canonical domain is
   `fathom.ks-design.art`; Cloudflare deploys `main` to production and creates

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -49,7 +49,7 @@
     --stroke: #ece8e0;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  html, body { height: 100%; }
+  html, body { height: 100%; overscroll-behavior: none; }
   body {
     background: var(--bg);
     color: var(--ink);
@@ -67,16 +67,28 @@
     display: block;
     touch-action: none;
   }
-  /* The water fills the phone screen. iPhone Safari stops the fixed viewport
-     at its bottom bar, but a canvas at the large viewport height is painted
-     on beneath the bar and shows through its glass; the status bar cannot be
-     painted at all, so it is tinted to the water instead (theme-color, kept
-     in step with the mood). Only iPhone portrait gets the taller canvas —
-     elsewhere the extra height would simply be cut off — and the chrome
-     keeps to the safe area (viewport-fit=cover), so it sits where it did. */
+  /* The water fills the phone screen. iPhone Safari clips the page at the
+     bottom of the document inside the zone of its bottom bar; a document one
+     viewport tall ends at the bar's top edge, so a taller fixed canvas was
+     simply cut there, and what showed under the bar was Safari's own flat
+     fill, sampled from the fixed canvas it found at the edge. So on iPhones
+     in portrait the canvas is laid out as document content instead: 100lvh
+     reaches the large viewport and the extra 120px runs on through the bar
+     zone below it (about 60px on a Dynamic Island phone, more in the
+     bottom-bar layout and in in-app browsers), where the bar's glass shows
+     it. body's overflow:hidden keeps the taller document from scrolling.
+     Literal lengths on purpose: a var() failing inside calc() would void the
+     100vh fallback. The status bar cannot be painted at all: Safari tints it
+     from the fixed element it finds at the top edge, so the #tint strip,
+     kept at the water's colour, stands in for the canvas there. Elsewhere
+     the extra height would just be cut off, so only iPhone portrait gets
+     this; the chrome keeps to the safe area (viewport-fit=cover) and stays
+     where it was. */
+  #tint { display: none; }
   @supports (-webkit-touch-callout: none) {
     @media (orientation: portrait) and (max-width: 600px) {
-      #stage { height: 100vh; height: 100lvh; }
+      #stage { position: absolute; height: calc(100vh + 120px); height: calc(100lvh + 120px); }
+      #tint { display: block; position: fixed; top: 0; left: 0; width: 100%; height: 8px; pointer-events: none; z-index: 1; }
     }
   }
   .chrome {
@@ -198,6 +210,7 @@
 </head>
 <body data-mood="day">
 <canvas id="stage" aria-hidden="true"></canvas>
+<div id="tint" aria-hidden="true"></div>
 
 <header class="chrome top">
   <!-- Ember's lab chrome as it ships on ember.ks-design.art (client decision,
@@ -447,7 +460,8 @@ function warpSprite(sp, phase, wig, slices) {
   const W = sp.w, Hh = sp.h, p = sp.pad || 0, cw = W - 2 * p, pad = Math.ceil(Math.abs(wig) * sp.hpx * 0.075) + 1, H2 = Hh + pad * 2;
   if (!warp) { const c = document.createElement('canvas'); warp = { canvas: c, ctx: c.getContext('2d') }; }
   if (warp.canvas.width < W) warp.canvas.width = W; if (warp.canvas.height < H2) warp.canvas.height = H2;
-  const x = warp.ctx; x.clearRect(0, 0, W, H2);
+  /* The scratch canvas keeps the last, larger sprite beyond this one's box, and a bilinear blit reads a texel past its source rect: the margin is cleared too, or a bright hairline of a neighbour's glow rides along the right and bottom edges of every smaller fish — the "seams" that showed around fish at midnight. */
+  const x = warp.ctx; x.clearRect(0, 0, Math.min(warp.canvas.width, W + 4), Math.min(warp.canvas.height, H2 + 4));
   /* The slices partition the picture itself, so a padded sprite is cut exactly like the bare one; the halo margins ride along with the end slices. */
   for (let i = 0, sx = p; i < slices; i++) { const ex = p + Math.round((i + 1) * cw / slices), sw = ex - sx; if (sw <= 0) continue; const t = waveT(sp, sx + sw / 2), dx = i ? sx : 0, dw = (i === slices - 1 ? W : ex) - dx; x.drawImage(sp.canvas, dx, 0, dw, Hh, dx, pad + wiggleOff(sp, t, phase, wig), dw, Hh); sx = ex; }
   return { canvas: warp.canvas, w: W, h: H2, pad };
@@ -527,8 +541,9 @@ function run(canvas, hooks) {
 /* ---------- motion ---------- */
 /* Fish sizes and speeds follow the short side of the canvas, so on a phone the school shrank to a
    crawl — a body a quarter the size at a quarter the pixels per second. The pace lifts small screens
-   back towards the desktop feel: 1 at a 1000px short side, about 1.9 on a 390px phone, 2.2 at most. */
-function paceFor(S) { return clamp(Math.pow(1000 / S.min, 0.7), 1, 2.2); }
+   part of the way back towards the desktop feel: 1 at a 1000px short side, about 1.45 on a 390px phone,
+   1.6 at most (a first cut at 1.9 read as too quick on the phone). */
+function paceFor(S) { return clamp(Math.pow(1000 / S.min, 0.4), 1, 1.6); }
 const MOTION = {
   drift(f, S, dt) { f.phase += f.wigRate * dt * (0.9 + 0.2 * Math.sin(f.burst)); f.bob += f.bobRate * dt; f.burst += 0.3 * dt; const sp = f.speed * (1 + 0.14 * Math.sin(f.burst)); f.x += sp * dt; f.y += Math.sin(f.bob) * f.L * 0.06 * dt; f.angle = Math.cos(f.bob) * 0.035; if (f.x - f.L * 1.0 > S.w) { f.x = -f.L * 1.0; f.y = S.h * (0.06 + 0.88 * Math.random()); } },
   lanes(f, S, dt) { f.phase += f.wigRate * dt * (0.9 + 0.2 * Math.sin(f.burst)); f.bob += f.bobRate * dt; f.burst += 0.3 * dt; const sp = f.speed * (1 + 0.14 * Math.sin(f.burst)); f.x += sp * dt; f.y = f.laneY + Math.sin(f.bob) * f.L * 0.07; f.angle = Math.cos(f.bob) * 0.03; if (f.x - f.L * 1.0 > S.w) { f.x = -f.L * 1.0; f.laneY = clamp(f.laneY + (Math.random() - 0.5) * S.h * 0.1, S.h * 0.05, S.h * 0.95); } },
@@ -559,8 +574,11 @@ function scene(canvas, cfg) {
   const params = new URLSearchParams(location.search); const forced = params.get('mood'); if (forced && MOOD_LABEL[forced]) st.auto = false;
   st.mood = forced && MOOD_LABEL[forced] ? forced : moodForDate();
   function bgFor(S, mood) { if (!st.bg[mood]) st.bg[mood] = paintBackground(S.w, S.h, Object.assign({}, BG[mood], cfg.bg || {}), S.dpr); return st.bg[mood]; }
-  /* Caustics scroll as repeating patterns, not as two abutting drawImage copies: at a fractional offset Chrome under-fills their seam row, and that hairline crawled across the water. */
-  function causticsFor(S) { st.causPat = [81, 82].map(seed => S.ctx.createPattern(causticLayer(S.w, S.h, seed, E.caustics.tint), 'repeat')); }
+  /* Caustics scroll as repeating patterns, not as two abutting drawImage copies. The tiles are built at device
+     resolution and scrolled by whole device pixels under an identity transform: any resampling at the repeat
+     edge — a fractional offset, or a tile in CSS pixels stretched to the device grid — leaves a hairline that
+     crawls across dark water, and midnight showed it. */
+  function causticsFor(S) { const c = S.canvas; st.causPat = [81, 82].map(seed => S.ctx.createPattern(causticLayer(c.width, c.height, seed, E.caustics.tint), 'repeat')); }
   /* Glow canvases are keyed by sprite; rebuilding the map after every sprite swap evicts the previous mood's canvases. */
   function glowsFor(l) { if (l.cfg.glow === false) return; for (const sp of l.sprites) if (!st.glows.has(sp)) st.glows.set(sp, glowSprite(sp, E.glowColor || 'rgba(255,200,110,1)', 9)); }
   function rebuildGlows() { st.glows = new Map(); for (const l of st.layers) glowsFor(l); }
@@ -616,7 +634,7 @@ function scene(canvas, cfg) {
       if (cfg.tint && (ground !== st.tintG || st.blendAt !== st.tintAt)) { st.tintG = ground; st.tintAt = st.blendAt; cfg.tint(groundTint(ground, S.dpr)); }
       const fx = st.fx || MOOD_FX[st.mood];
       if (st.rays.length && fx.rays > 0.02) { ctx.save(); ctx.globalCompositeOperation = 'lighter'; ctx.globalAlpha = fx.rays * (0.55 + 0.45 * Math.sin(S.t * 0.35)); ctx.drawImage(st.rays[0], 0, 0); ctx.globalAlpha = fx.rays * (0.55 + 0.45 * Math.sin(S.t * 0.35 + Math.PI)); ctx.drawImage(st.rays[1], 0, 0); ctx.restore(); }
-      if (st.causPat && fx.caustics > 0.02) { ctx.save(); ctx.globalCompositeOperation = 'lighter'; ctx.globalAlpha = fx.caustics; const o1 = (S.t * 9) % S.w, o2 = (S.t * 6) % S.h; ctx.translate(o1, 0); ctx.fillStyle = st.causPat[0]; ctx.fillRect(-o1, 0, S.w, S.h); ctx.translate(-o1, o2); ctx.fillStyle = st.causPat[1]; ctx.fillRect(0, -o2, S.w, S.h); ctx.restore(); }
+      if (st.causPat && fx.caustics > 0.02) { ctx.save(); ctx.setTransform(1, 0, 0, 1, 0, 0); ctx.globalCompositeOperation = 'lighter'; ctx.globalAlpha = fx.caustics; const W = S.canvas.width, H = S.canvas.height, o1 = Math.round(S.t * 9 * S.dpr) % W, o2 = Math.round(S.t * 6 * S.dpr) % H; ctx.translate(o1, 0); ctx.fillStyle = st.causPat[0]; ctx.fillRect(-o1, 0, W, H); ctx.translate(-o1, o2); ctx.fillStyle = st.causPat[1]; ctx.fillRect(0, -o2, W, H); ctx.restore(); }
       st.layers.forEach((l, i) => { const k = (l.cfg.parallax == null ? (i - (st.layers.length - 1) / 2) * 0.05 : l.cfg.parallax) * (cfg.pointerParallax == null ? 1 : cfg.pointerParallax) * S.min; ctx.save(); ctx.translate(-st.px * k, -st.py * k * 0.6);
         for (const f of l.fish) { const slices = f.L > S.min * 0.25 ? 22 : 14; const o = { scale: f.L / f.sp.L, phase: f.phase, angle: f.angle, flip: f.flip, alpha: f.alpha, wig: l.cfg.wig == null ? 1 : l.cfg.wig, slices };
           const glowA = (E.glow == null ? 0.22 : E.glow) * fx.glow * (l.cfg.glow === false ? 0 : 1); if (glowA > 0.01) { const pulse = glowA * (0.8 + 0.3 * Math.sin(S.t * 1.2 + f.bob * 3)); const gs = st.glows.get(f.sp); if (gs) { ctx.save(); ctx.globalCompositeOperation = 'lighter'; drawFish(ctx, gs, f.x, f.y, Object.assign({}, o, { alpha: pulse * f.alpha, slices: 6 })); ctx.restore(); } }
@@ -644,10 +662,10 @@ return { makeSprite, rasterSprite, loadImages, drawFish, blurSprite, fogSprite, 
   CFG.static = reduced.matches || params.get("motion") === "reduce";
   const canvas = document.getElementById("stage");
   const status = document.getElementById("mood-status");
-  /* Safari paints its own status bar (and, on iOS 26, the strip under its bottom controls) in a colour
-     taken from theme-color or from the nearest fixed element's background; both follow the water. */
-  const theme = document.querySelector('meta[name="theme-color"]');
-  CFG.tint = (color) => { theme.setAttribute("content", color); canvas.style.backgroundColor = color; };
+  /* Safari paints its own status bar in a colour it takes from theme-color (iOS 15–18) or, on iOS 26,
+     samples from the fixed element at the page's top edge — the #tint strip; both follow the water. */
+  const theme = document.querySelector('meta[name="theme-color"]'), tint = document.getElementById("tint");
+  CFG.tint = (color) => { theme.setAttribute("content", color); tint.style.background = `linear-gradient(${color}, ${color} 3px, transparent)`; };
   const buttons = Array.from(document.querySelectorAll(".ctl"));
   function boot(images) {
     if (images && images.length) CFG.raster = images;

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>Fathom — ks-design lab</title>
 <meta name="description" content="Study 03 of the ks·design lab: a school of sequined goldfish drifts endlessly through painted water that follows your local time of day.">
 <link rel="canonical" href="https://fathom.ks-design.art">
 <meta name="color-scheme" content="light dark">
+<meta name="theme-color" content="#a7b1b9">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTYgMjU2Ij48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImEiIHgyPSIwIiB5Mj0iMSI+PHN0b3Agc3RvcC1jb2xvcj0iIzFjMmMzYyIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzE0MWYyYiIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJiIj48c3RvcCBzdG9wLWNvbG9yPSIjZjhiODNhIi8+PHN0b3Agb2Zmc2V0PSIuNDUiIHN0b3AtY29sb3I9IiNlNjhjMmMiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNiODY3MmEiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iYyI+PHN0b3Agc3RvcC1jb2xvcj0iI2ZiYzE0MiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2YwOWEyZSIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJkIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIHN0b3AtY29sb3I9IiM3YTNhMTAiIHN0b3Atb3BhY2l0eT0iLjI4Ii8+PHN0b3Agb2Zmc2V0PSIuNDUiIHN0b3AtY29sb3I9IiM3YTNhMTAiIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2ZmZTJhMCIgc3RvcC1vcGFjaXR5PSIuMTgiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iZSIgeDE9Ii4zNSIgeTE9Ii44NiIgeDI9Ii40OCIgeTI9Ii4xIj48c3RvcCBzdG9wLWNvbG9yPSIjZDlhMzVjIiBzdG9wLW9wYWNpdHk9Ii45NSIvPjxzdG9wIG9mZnNldD0iLjM1IiBzdG9wLWNvbG9yPSIjZWNlN2RjIiBzdG9wLW9wYWNpdHk9Ii44NSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2ZmZiIgc3RvcC1vcGFjaXR5PSIuNTUiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iZiI+PHN0b3Agc3RvcC1jb2xvcj0iI2M5OGI0OCIgc3RvcC1vcGFjaXR5PSIuOTUiLz48c3RvcCBvZmZzZXQ9Ii4zIiBzdG9wLWNvbG9yPSIjZWNlN2RjIiBzdG9wLW9wYWNpdHk9Ii44NSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2ZmZiIgc3RvcC1vcGFjaXR5PSIuNSIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJnIiB4MT0iLjIzIiB4Mj0iLjc5IiB5Mj0iLjkzIj48c3RvcCBzdG9wLWNvbG9yPSIjZDlhMzVjIiBzdG9wLW9wYWNpdHk9Ii45NSIvPjxzdG9wIG9mZnNldD0iLjQiIHN0b3AtY29sb3I9IiNlY2U3ZGMiIHN0b3Atb3BhY2l0eT0iLjg1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjZmZmIiBzdG9wLW9wYWNpdHk9Ii41NSIvPjwvbGluZWFyR3JhZGllbnQ+PGxpbmVhckdyYWRpZW50IGlkPSJoIiB4MT0iLjI4IiB4Mj0iLjgzIiB5Mj0iLjk2Ij48c3RvcCBzdG9wLWNvbG9yPSIjYzk4YjQ4IiBzdG9wLW9wYWNpdHk9Ii45NSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iI2ZmZiIgc3RvcC1vcGFjaXR5PSIuNTUiLz48L2xpbmVhckdyYWRpZW50PjxmaWx0ZXIgaWQ9ImkiPjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjQiLz48L2ZpbHRlcj48ZmlsdGVyIGlkPSJqIiB4PSItLjQiIHk9Ii0uNCIgd2lkdGg9IjEuOCIgaGVpZ2h0PSIxLjgiPjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEyIi8+PC9maWx0ZXI+PHBhdGggaWQ9ImsiIGQ9Ik0xNTIgMTEwQzE3MCA5OCAxOTIgODQgMjA2IDc3QzIxOCA3MiAyMjYgODQgMjE4IDk2QzIxMCAxMDggMTk4IDExOCAxODQgMTI3QzE5OCAxMzYgMjEwIDE1MCAyMTggMTYyQzIyNiAxNzYgMjE0IDE4NyAyMDIgMTc4QzE5MCAxNjggMTcwIDE1MiAxNTIgMTQyWiIvPjxwYXRoIGlkPSJsIiBkPSJNMTAwIDkzQzEwNCA3OCAxMTIgNjAgMTI0IDU1QzEzNiA1MSAxNDYgNjAgMTQ2IDcyQzE0NiA4MiAxNTIgOTIgMTYzIDEwMUMxNTAgMTAwIDEyNSA5OCAxMDAgOTNaIi8+PHBhdGggaWQ9Im0iIGQ9Ik0xMzggMTQxQzE0NSAxNTEgMTU0IDE2MyAxNjIgMTY4QzE2NyAxNjkgMTY2IDE2MSAxNjMgMTU1QzE1OSAxNDkgMTU1IDE0NSAxNTEgMTQyWiIvPjxwYXRoIGlkPSJuIiBkPSJNNDggMTI2QzU0IDExMiA2NiA5OCA4NCA5M0MxMDAgODkgMTIyIDkwIDEzOCA5N0MxNDggMTAxIDE1MyAxMDggMTU0IDExMkwxNTQgMTQxQzE1MiAxNDYgMTQ2IDE1MiAxMzYgMTU2QzEyMiAxNjIgMTAwIDE2NCA4NCAxNTlDNjYgMTU0IDU0IDE0MCA0OCAxMjZaIi8+PHBhdGggaWQ9Im8iIGQ9Ik04NiAxNTZDOTIgMTczIDEwNSAxOTEgMTIwIDE5OEMxMjkgMjAxIDEyOCAxOTIgMTI0IDE4MkMxMTkgMTcxIDExMiAxNjIgMTA2IDE1N1oiLz48ZyBpZD0icCI+PHVzZSBocmVmPSIjayIvPjx1c2UgaHJlZj0iI2wiLz48dXNlIGhyZWY9IiNtIi8+PHVzZSBocmVmPSIjbiIvPjx1c2UgaHJlZj0iI28iLz48L2c+PC9kZWZzPjxyZWN0IHdpZHRoPSIyNTYiIGhlaWdodD0iMjU2IiByeD0iNDAiIGZpbGw9InVybCgjYSkiLz48ZyB0cmFuc2Zvcm09Im1hdHJpeCgtMSAwIDAgMSAyNTYgMCkiPjx1c2UgaHJlZj0iI3AiIGZpbGw9IiNmZmQ5YTAiIG9wYWNpdHk9Ii4zNSIgZmlsdGVyPSJ1cmwoI2opIi8+PHVzZSBocmVmPSIjbiIgZmlsbD0iI2ZmYWIzYSIgb3BhY2l0eT0iLjYiIGZpbHRlcj0idXJsKCNpKSIvPjx1c2UgaHJlZj0iI2siIGZpbGw9InVybCgjZikiLz48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1vcGFjaXR5PSIuMzUiIHN0cm9rZS13aWR0aD0iMS4yIiBkPSJNMTU2IDExNEMxNzYgMTA0IDE5NiA5MiAyMTAgODRNMTU2IDEyMkMxNzQgMTE0IDE5MCAxMDYgMjA0IDk4TTE1NiAxMzJDMTcyIDEzOCAxODggMTQ4IDIwMiAxNjJNMTU2IDEzOUMxNzYgMTQ4IDE5NiAxNjAgMjEwIDE3Mk0xMDQgOTJDMTEyIDc4IDEyMCA2NiAxMjggNjBNMTE4IDk2QzEyOCA4NCAxMzYgNzQgMTQwIDY4Ii8+PHVzZSBocmVmPSIjbCIgZmlsbD0idXJsKCNlKSIvPjx1c2UgaHJlZj0iI20iIGZpbGw9InVybCgjaCkiLz48dXNlIGhyZWY9IiNuIiBmaWxsPSJ1cmwoI2IpIi8+PHBhdGggZmlsbD0idXJsKCNjKSIgZD0iTTQ4IDEyNkM1NCAxMTIgNjYgOTggODQgOTNDODYgOTIuNSA4OCA5Mi4zIDkxIDkyLjJDMTA0IDEwOCAxMDQgMTQ0IDkxIDE2MC4yQzg4IDE2MCA4NiAxNTkuNSA4NCAxNTlDNjYgMTU0IDU0IDE0MCA0OCAxMjZaIi8+PHVzZSBocmVmPSIjbiIgZmlsbD0idXJsKCNkKSIvPjx1c2UgaHJlZj0iI28iIGZpbGw9InVybCgjZykiLz48Y2lyY2xlIGN4PSI3MCIgY3k9IjEyNiIgcj0iNi41IiBmaWxsPSIjNWEyZTBmIi8+PGNpcmNsZSBjeD0iNzAiIGN5PSIxMjYiIHI9IjMiIGZpbGw9IiMzZDFjMDciLz48L2c+PC9zdmc+">
 <style>
   :root {
@@ -59,11 +60,24 @@
   }
   #stage {
     position: fixed;
-    inset: 0;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     display: block;
     touch-action: none;
+  }
+  /* The water fills the phone screen. iPhone Safari stops the fixed viewport
+     at its bottom bar, but a canvas at the large viewport height is painted
+     on beneath the bar and shows through its glass; the status bar cannot be
+     painted at all, so it is tinted to the water instead (theme-color, kept
+     in step with the mood). Only iPhone portrait gets the taller canvas —
+     elsewhere the extra height would simply be cut off — and the chrome
+     keeps to the safe area (viewport-fit=cover), so it sits where it did. */
+  @supports (-webkit-touch-callout: none) {
+    @media (orientation: portrait) and (max-width: 600px) {
+      #stage { height: 100vh; height: 100lvh; }
+    }
   }
   .chrome {
     position: fixed;
@@ -79,6 +93,9 @@
     justify-content: space-between;
     align-items: baseline;
     padding: 22px 28px;
+    padding-top: calc(22px + env(safe-area-inset-top, 0px));
+    padding-left: calc(28px + env(safe-area-inset-left, 0px));
+    padding-right: calc(28px + env(safe-area-inset-right, 0px));
   }
   .tag {
     font-size: 11px;
@@ -119,6 +136,9 @@
     align-items: center;
     gap: 14px;
     padding: 0 20px 18px;
+    padding-left: calc(20px + env(safe-area-inset-left, 0px));
+    padding-right: calc(20px + env(safe-area-inset-right, 0px));
+    padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   }
   .controls {
     display: flex;
@@ -166,9 +186,9 @@
   footer a:hover { border-color: var(--gold); color: var(--gold); }
   footer a:focus-visible { outline: 2px solid var(--stroke); outline-offset: 2px; }
   @media (max-width: 560px) {
-    .top { padding: 16px 18px; }
+    .top { padding: 16px 18px; padding-top: calc(16px + env(safe-area-inset-top, 0px)); padding-left: calc(18px + env(safe-area-inset-left, 0px)); padding-right: calc(18px + env(safe-area-inset-right, 0px)); }
     .tag { font-size: 10px; letter-spacing: 0.16em; }
-    .bottom { gap: 12px; padding-bottom: 14px; }
+    .bottom { gap: 12px; padding-bottom: calc(14px + env(safe-area-inset-bottom, 0px)); }
     .ctl { min-width: 0; padding: 0 12px; height: 34px; }
   }
   @media (prefers-reduced-motion: reduce) {
@@ -246,9 +266,9 @@ PALETTES.midnight = { white: ['#ffffff', '#f3f5f8', '#e6eaef'], silver: ['#aebbc
   fin: { fill: 'rgba(225,222,215,1)', ray: 'rgba(160,140,120,0.5)', light: 'rgba(255,255,255,0.55)', spark: 'rgba(255,255,255,0.85)', tint: 'rgba(200,150,110,0.2)' },
   eye: { iris: '#d3873a', ring: '#5a2e0f', pupil: '#000000' }, rim: 'rgba(0,0,0,0.5)', glint: '#fff1cf', bloom: 'rgba(255,238,205,1)' };
 const BG = {
-  day: { top: '#aab4bb', bottom: '#8fa0ad', accent: '#7c8d9b', light: '#d8d1c2', warm: '#c9c0ae', vignette: 0.28, strokes: 700, vertical: true, noise: 0.05 },
-  dusk: { top: '#6f8397', bottom: '#4b6076', accent: '#3f5568', light: '#9aa9b8', warm: '#8f8c84', vignette: 0.42, strokes: 600, vertical: true, noise: 0.06 },
-  midnight: { top: '#141f2b', bottom: '#060b10', accent: '#1c2c3c', light: '#2b3f52', warm: '#2a2f36', vignette: 0.6, strokes: 500, vertical: true, noise: 0.08 },
+  day: { top: '#aab4bb', bottom: '#8fa0ad', accent: '#7c8d9b', light: '#d8d1c2', warm: '#c9c0ae', vignette: 0.28, strokes: 840, vertical: true, noise: 0.05 },
+  dusk: { top: '#6f8397', bottom: '#4b6076', accent: '#3f5568', light: '#9aa9b8', warm: '#8f8c84', vignette: 0.42, strokes: 720, vertical: true, noise: 0.06 },
+  midnight: { top: '#141f2b', bottom: '#060b10', accent: '#1c2c3c', light: '#2b3f52', warm: '#2a2f36', vignette: 0.6, strokes: 600, vertical: true, noise: 0.08 },
 };
 
 /* ---------- goldfish geometry (u: 0 snout → 1 peduncle; v in body heights) ---------- */
@@ -448,14 +468,21 @@ function tickGlints(f, dt, rate, style) { style = style || {}; if (!f.glints) f.
   if (tiles.length && Math.random() < rate * dt) f.glints.push({ i: (Math.random() * tiles.length) | 0, t: 0, life: (style.life || 0.8) * (0.6 + 0.8 * Math.random()), k: (style.intensity || 1) * (0.5 + 0.5 * Math.random()), star: Math.random() < (style.star == null ? 0.3 : style.star), rot: Math.random() * 3, color: style.color || '#ffffff' });
   for (const g of f.glints) g.t += dt; if (f.glints.length) f.glints = f.glints.filter(g => g.t < g.life); }
 
-/* ---------- background (vertical brush marks like the reference) ---------- */
+/* ---------- background (vertical brush marks like the reference) ----------
+   The marks are washes, not bars. Each one is a tapered polygon laid on a coarse canvas — most on a
+   quarter-scale sheet, the finer streaks on a half-scale one — and each sheet is drawn onto the ground
+   once, softened by a single blur. Painted at full size as hard-edged rectangles, the marks overlapped
+   into fine vertical stripes and flat-ended blocks that read as interference rather than paint. */
 function noiseTile(rnd) { const n = 128, c = document.createElement('canvas'); c.width = c.height = n; const x = c.getContext('2d'), img = x.createImageData(n, n), d = img.data; for (let i = 0; i < d.length; i += 4) { const v = 110 + rnd() * 90; d[i] = d[i + 1] = d[i + 2] = v; d[i + 3] = 255; } x.putImageData(img, 0, 0); return c; }
 function paintBackground(w, h, opts, dpr) {
   const o = Object.assign({ seed: 5, noise: 0.06 }, typeof opts === 'string' ? BG[opts] : (opts || {})); dpr = dpr || 1;
   const c = document.createElement('canvas'); c.width = Math.ceil(w * dpr); c.height = Math.ceil(h * dpr); const ctx = c.getContext('2d'); ctx.scale(dpr, dpr); const rnd = mulberry32(o.seed);
   const g = ctx.createLinearGradient(0, 0, w * 0.1, h); g.addColorStop(0, o.top); g.addColorStop(1, o.bottom); ctx.fillStyle = g; ctx.fillRect(0, 0, w, h);
   const cols = [o.top, o.bottom, o.accent, o.light, o.light, o.warm], S = Math.max(w, h);
-  for (let i = 0; i < o.strokes; i++) { const x = rnd() * w, y = rnd() * h; const vert = o.vertical ? rnd() < 0.8 : rnd() < 0.12; const len = S * (0.05 + 0.3 * rnd()), th = S * (0.003 + 0.02 * rnd()); ctx.save(); ctx.translate(x, y); ctx.rotate((vert ? Math.PI / 2 : 0) + (rnd() - 0.5) * 0.12); ctx.globalAlpha = 0.04 + 0.12 * rnd(); ctx.fillStyle = cols[(rnd() * cols.length) | 0]; ctx.fillRect(-len / 2, -th / 2, len, th); ctx.restore(); }
+  const sheets = [{ q: 4, blur: 2 }, { q: 2, blur: 0.7 }].map(sh => { const sc = document.createElement('canvas'); sc.width = Math.ceil(w / sh.q); sc.height = Math.ceil(h / sh.q); const sx = sc.getContext('2d'); sx.scale(1 / sh.q, 1 / sh.q); return { canvas: sc, ctx: sx, blur: sh.blur }; });
+  for (let i = 0; i < o.strokes; i++) { const x = rnd() * w, y = rnd() * h; const vert = o.vertical ? rnd() < 0.88 : rnd() < 0.12; const len = S * (0.05 + 0.3 * rnd()), th = S * (0.004 + 0.024 * rnd()), e = len * 0.22, col = cols[(rnd() * cols.length) | 0], a = (0.06 + 0.16 * rnd()) * (vert ? 1 : 0.7), sx = sheets[rnd() < 0.7 ? 0 : 1].ctx;
+    sx.save(); sx.translate(x, y); sx.rotate((vert ? Math.PI / 2 : 0) + (rnd() - 0.5) * 0.12); sx.globalAlpha = a; sx.fillStyle = col; sx.beginPath(); sx.moveTo(-len / 2, 0); sx.lineTo(e - len / 2, -th / 2); sx.lineTo(len / 2 - e, -th / 2); sx.lineTo(len / 2, 0); sx.lineTo(len / 2 - e, th / 2); sx.lineTo(e - len / 2, th / 2); sx.closePath(); sx.fill(); sx.restore(); }
+  for (const sh of sheets) { ctx.save(); ctx.filter = `blur(${sh.blur}px)`; ctx.drawImage(sh.canvas, 0, 0, w, h); ctx.restore(); }
   if (o.noise > 0) { ctx.save(); ctx.globalAlpha = o.noise; ctx.globalCompositeOperation = 'overlay'; ctx.fillStyle = ctx.createPattern(noiseTile(rnd), 'repeat'); ctx.fillRect(0, 0, w, h); ctx.restore(); }
   if (o.vignette > 0) { const vg = ctx.createRadialGradient(w / 2, h / 2, Math.min(w, h) * 0.35, w / 2, h / 2, S * 0.75); vg.addColorStop(0, 'rgba(10,20,30,0)'); vg.addColorStop(1, `rgba(10,20,30,${o.vignette})`); ctx.fillStyle = vg; ctx.fillRect(0, 0, w, h); }
   return c;
@@ -463,6 +490,9 @@ function paintBackground(w, h, opts, dpr) {
 /* Wraps at the edges: the scene tiles it as a repeating pattern, so a blob crossing an edge is painted again on the far side. */
 function causticLayer(w, h, seed, tint) { const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'), rnd = mulberry32(seed); tint = tint || '180,215,255'; for (let i = 0; i < 90; i++) { const x = rnd() * w, y = rnd() * h, r = Math.min(w, h) * (0.04 + 0.12 * rnd()), a = 0.05 + 0.08 * rnd(); for (const dx of [-w, 0, w]) for (const dy of [-h, 0, h]) { const bx = x + dx, by = y + dy; if (bx + r <= 0 || bx - r >= w || by + r <= 0 || by - r >= h) continue; const g = ctx.createRadialGradient(bx, by, 0, bx, by, r); g.addColorStop(0, `rgba(${tint},${a})`); g.addColorStop(1, `rgba(${tint},0)`); ctx.fillStyle = g; ctx.beginPath(); ctx.arc(bx, by, r, 0, TAU); ctx.fill(); } } return c; }
 function rayLayer(w, h, seed, strength) { const c = document.createElement('canvas'); c.width = w; c.height = h; const ctx = c.getContext('2d'), rnd = mulberry32(seed); strength = strength == null ? 1 : strength; const ox = w * (0.15 + 0.3 * rnd()), oy = -h * 0.35, len = h * 1.9; for (let i = 0; i < 16; i++) { const a = Math.PI / 2 + (rnd() - 0.4) * 0.7, wd = 0.02 + 0.06 * rnd(); const g = ctx.createLinearGradient(ox, oy, ox + Math.cos(a) * len, oy + Math.sin(a) * len); g.addColorStop(0, `rgba(255,250,235,${(0.16 + 0.14 * rnd()) * strength})`); g.addColorStop(0.55, `rgba(255,250,235,${0.05 * strength})`); g.addColorStop(1, 'rgba(255,250,235,0)'); ctx.fillStyle = g; ctx.beginPath(); ctx.moveTo(ox, oy); ctx.lineTo(ox + Math.cos(a - wd) * len, oy + Math.sin(a - wd) * len); ctx.lineTo(ox + Math.cos(a + wd) * len, oy + Math.sin(a + wd) * len); ctx.closePath(); ctx.fill(); } return c; }
+
+/* The mean colour of the water's top edge (28 CSS px), so the browser bars outside the page can be tinted to match. */
+function groundTint(ground, dpr) { const c = document.createElement('canvas'); c.width = 16; c.height = 2; const x = c.getContext('2d'); x.drawImage(ground, 0, 0, ground.width, Math.min(ground.height, Math.max(1, Math.round(28 * dpr))), 0, 0, 16, 2); const d = x.getImageData(0, 0, 16, 2).data; let r = 0, g = 0, b = 0; for (let i = 0; i < d.length; i += 4) { r += d[i]; g += d[i + 1]; b += d[i + 2]; } const n = d.length / 4; return `rgb(${Math.round(r / n)},${Math.round(g / n)},${Math.round(b / n)})`; }
 
 /* ---------- time of day ---------- */
 function moodForDate(d) { d = d || new Date(); const h = d.getHours() + d.getMinutes() / 60; if (h >= 7 && h < 16.5) return 'day'; if ((h >= 16.5 && h < 20.5) || (h >= 5.5 && h < 7)) return 'dusk'; return 'midnight'; }
@@ -474,13 +504,17 @@ const MOOD_FX = { day: { glow: 0, caustics: 0.3, rays: 0.55, motes: 0.5, sweep: 
 function run(canvas, hooks) {
   const ctx = canvas.getContext('2d', { alpha: false });
   const S = { canvas, ctx, w: 0, h: 0, dpr: 1, t: 0, running: true, visible: true, inView: true, pointer: { x: -1e5, y: -1e5, down: false, active: false }, min: 0 };
-  function fit() { S.dpr = Math.min(window.devicePixelRatio || 1, 2); const r = canvas.getBoundingClientRect(); S.w = Math.max(2, Math.round(r.width)); S.h = Math.max(2, Math.round(r.height)); S.min = Math.min(S.w, S.h); canvas.width = Math.round(S.w * S.dpr); canvas.height = Math.round(S.h * S.dpr); }
+  function measure() { const r = canvas.getBoundingClientRect(); return { dpr: Math.min(window.devicePixelRatio || 1, 2), w: Math.max(2, Math.round(r.width)), h: Math.max(2, Math.round(r.height)) }; }
+  function changed() { const m = measure(); return m.w !== S.w || m.h !== S.h || m.dpr !== S.dpr; }
+  /* Setting a canvas's width clears it even to the same value, so the bitmap is only touched when the size really changed. */
+  function fit() { const m = measure(); S.dpr = m.dpr; S.w = m.w; S.h = m.h; S.min = Math.min(S.w, S.h); const cw = Math.round(S.w * S.dpr), ch = Math.round(S.h * S.dpr); if (canvas.width !== cw) canvas.width = cw; if (canvas.height !== ch) canvas.height = ch; }
   let ready = false; function ensure() { fit(); if (!ready && S.w > 2 && S.h > 2) { ready = true; hooks.setup && hooks.setup(S); } return ready; } ensure();
   let last = performance.now(), raf = 0;
-  function frame(now) { raf = 0; if (!S.running || !S.visible) return; if (!ready && !ensure()) { last = now; raf = requestAnimationFrame(frame); return; } const dt = Math.min(0.05, (now - last) / 1000); last = now; S.t += dt; hooks.update && hooks.update(S, dt); ctx.setTransform(S.dpr, 0, 0, S.dpr, 0, 0); hooks.draw(S, ctx, dt); raf = requestAnimationFrame(frame); }
+  function frame(now) { raf = 0; if (!S.running || !S.visible) return; if (!ready && !ensure()) { last = now; raf = requestAnimationFrame(frame); return; } const dt = Math.min(0.1, (now - last) / 1000); last = now; S.t += dt; hooks.update && hooks.update(S, dt); ctx.setTransform(S.dpr, 0, 0, S.dpr, 0, 0); hooks.draw(S, ctx, dt); raf = requestAnimationFrame(frame); }
   function renderOnce() { if (!ensure()) return; hooks.update && hooks.update(S, 0); ctx.setTransform(S.dpr, 0, 0, S.dpr, 0, 0); hooks.draw(S, ctx, 0); }
   function start() { if (hooks.static) { renderOnce(); return; } if (!raf && S.running && S.visible) { last = performance.now(); raf = requestAnimationFrame(frame); } }
-  let rt = 0; window.addEventListener('resize', () => { clearTimeout(rt); rt = setTimeout(() => { if (!ready) { ensure(); return; } fit(); hooks.resize && hooks.resize(S); }, 80); });
+  /* iPhone Safari fires resize on tab switches and bar toggles without a size change; those must not rebuild the scene (or, under reduced motion, blank the still frame). */
+  let rt = 0; window.addEventListener('resize', () => { clearTimeout(rt); rt = setTimeout(() => { if (!ready) { ensure(); return; } if (!changed()) return; fit(); hooks.resize && hooks.resize(S); }, 80); });
   document.addEventListener('visibilitychange', () => { S.visible = !document.hidden && S.inView; start(); });
   if ('IntersectionObserver' in window) new IntersectionObserver(e => { S.inView = e[0].isIntersecting; S.visible = S.inView && !document.hidden; start(); }).observe(canvas);
   canvas.addEventListener('pointermove', e => { const r = canvas.getBoundingClientRect(); S.pointer.x = e.clientX - r.left; S.pointer.y = e.clientY - r.top; S.pointer.active = true; });
@@ -491,6 +525,10 @@ function run(canvas, hooks) {
 }
 
 /* ---------- motion ---------- */
+/* Fish sizes and speeds follow the short side of the canvas, so on a phone the school shrank to a
+   crawl — a body a quarter the size at a quarter the pixels per second. The pace lifts small screens
+   back towards the desktop feel: 1 at a 1000px short side, about 1.9 on a 390px phone, 2.2 at most. */
+function paceFor(S) { return clamp(Math.pow(1000 / S.min, 0.7), 1, 2.2); }
 const MOTION = {
   drift(f, S, dt) { f.phase += f.wigRate * dt * (0.9 + 0.2 * Math.sin(f.burst)); f.bob += f.bobRate * dt; f.burst += 0.3 * dt; const sp = f.speed * (1 + 0.14 * Math.sin(f.burst)); f.x += sp * dt; f.y += Math.sin(f.bob) * f.L * 0.06 * dt; f.angle = Math.cos(f.bob) * 0.035; if (f.x - f.L * 1.0 > S.w) { f.x = -f.L * 1.0; f.y = S.h * (0.06 + 0.88 * Math.random()); } },
   lanes(f, S, dt) { f.phase += f.wigRate * dt * (0.9 + 0.2 * Math.sin(f.burst)); f.bob += f.bobRate * dt; f.burst += 0.3 * dt; const sp = f.speed * (1 + 0.14 * Math.sin(f.burst)); f.x += sp * dt; f.y = f.laneY + Math.sin(f.bob) * f.L * 0.07; f.angle = Math.cos(f.bob) * 0.03; if (f.x - f.L * 1.0 > S.w) { f.x = -f.L * 1.0; f.laneY = clamp(f.laneY + (Math.random() - 0.5) * S.h * 0.1, S.h * 0.05, S.h * 0.95); } },
@@ -513,7 +551,7 @@ function makeLayer(S, L, cfg, idx, mood) {
   for (let i = 0; i < L.count; i++) { const Lf = m * lerp(L.min, L.max, rnd()); const spi = i % n; const lane = i % lanes; const laneY = S.h * (0.06 + 0.88 * (lane + 0.5) / lanes) + (rnd() - 0.5) * S.h * 0.5 / lanes;
     const scatter = motion === 'boids' || motion === 'follow' || motion === 'rise';
     fish.push({ x: scatter ? S.w * (0.05 + 0.9 * rnd()) : (i / L.count) * (S.w + Lf * 2) - Lf + (rnd() - 0.5) * S.w / L.count, y: motion === 'rise' ? rnd() * (S.h + Lf) - Lf / 2 : laneY, laneY, L: Lf, spi, sp: sprites[spi], scale: Lf / sprites[spi].L, phase: rnd() * TAU, wigRate: (L.wigRate || cfg.wigRate || 3.2) * (0.85 + 0.3 * rnd()),
-      speed: Lf * lerp(L.speed ? L.speed[0] : 0.12, L.speed ? L.speed[1] : 0.2, rnd()) * (cfg.speedK || 1), bob: rnd() * TAU, bobRate: 0.3 + 0.4 * rnd(), r: rnd(), r2: rnd(), angle: 0, flip: false, alpha: L.alpha == null ? 1 : L.alpha, vx: 0, vy: 0, face: 1, burst: rnd() * TAU, glints: [] }); }
+      speed: Lf * lerp(L.speed ? L.speed[0] : 0.12, L.speed ? L.speed[1] : 0.2, rnd()) * (cfg.speedK || 1) * paceFor(S), bob: rnd() * TAU, bobRate: 0.3 + 0.4 * rnd(), r: rnd(), r2: rnd(), angle: 0, flip: false, alpha: L.alpha == null ? 1 : L.alpha, vx: 0, vy: 0, face: 1, burst: rnd() * TAU, glints: [] }); }
   fish.sort((a, b) => a.L - b.L); return { cfg: L, fish, sprites, idx };
 }
 function scene(canvas, cfg) {
@@ -553,8 +591,8 @@ function scene(canvas, cfg) {
       if (E.rays) st.rays = [rayLayer(S.w, S.h, 191, E.rays.strength), rayLayer(S.w, S.h, 192, E.rays.strength)];
       if (E.motes) st.motes = Array.from({ length: E.motes }, () => ({ x: Math.random() * S.w, y: Math.random() * S.h, s: 0.6 + Math.random() * 1.7, v: 3 + Math.random() * 9, p: Math.random() * 7, a: 0.12 + Math.random() * 0.3 }));
       cfg.setup && cfg.setup(S, st); },
-    resize(S) { const d = st.dims || { w: S.w, h: S.h, min: S.min }; const kx = S.w / d.w, ky = S.h / d.h, km = S.min / d.min;
-      for (const l of st.layers) for (const f of l.fish) { f.x *= kx; f.y *= ky; f.laneY *= ky; f.L *= km; f.scale = f.L / f.sp.L; f.speed *= km; }
+    resize(S) { const d = st.dims || { w: S.w, h: S.h, min: S.min }; const kx = S.w / d.w, ky = S.h / d.h, km = S.min / d.min, kp = paceFor(S) / paceFor(d);
+      for (const l of st.layers) for (const f of l.fish) { f.x *= kx; f.y *= ky; f.laneY *= ky; f.L *= km; f.scale = f.L / f.sp.L; f.speed *= km * kp; }
       for (const m of st.motes) { m.x *= kx; m.y *= ky; }
       st.dims = { w: S.w, h: S.h, min: S.min }; st.bg = {}; st.blendBg = null; st.blendAt = -1;
       /* a captured base (retargeted fade) is rescaled rather than dropped, so the ground does not snap back mid-transition */
@@ -573,7 +611,9 @@ function scene(canvas, cfg) {
       cfg.update && cfg.update(S, dt, st);
     },
     draw(S, ctx) {
-      ctx.drawImage(st.moodTo && st.blendBg ? st.blendBg : (st.baseBg || bgFor(S, st.mood)), 0, 0, S.w, S.h);
+      const ground = st.moodTo && st.blendBg ? st.blendBg : (st.baseBg || bgFor(S, st.mood));
+      ctx.drawImage(ground, 0, 0, S.w, S.h);
+      if (cfg.tint && (ground !== st.tintG || st.blendAt !== st.tintAt)) { st.tintG = ground; st.tintAt = st.blendAt; cfg.tint(groundTint(ground, S.dpr)); }
       const fx = st.fx || MOOD_FX[st.mood];
       if (st.rays.length && fx.rays > 0.02) { ctx.save(); ctx.globalCompositeOperation = 'lighter'; ctx.globalAlpha = fx.rays * (0.55 + 0.45 * Math.sin(S.t * 0.35)); ctx.drawImage(st.rays[0], 0, 0); ctx.globalAlpha = fx.rays * (0.55 + 0.45 * Math.sin(S.t * 0.35 + Math.PI)); ctx.drawImage(st.rays[1], 0, 0); ctx.restore(); }
       if (st.causPat && fx.caustics > 0.02) { ctx.save(); ctx.globalCompositeOperation = 'lighter'; ctx.globalAlpha = fx.caustics; const o1 = (S.t * 9) % S.w, o2 = (S.t * 6) % S.h; ctx.translate(o1, 0); ctx.fillStyle = st.causPat[0]; ctx.fillRect(-o1, 0, S.w, S.h); ctx.translate(-o1, o2); ctx.fillStyle = st.causPat[1]; ctx.fillRect(0, -o2, S.w, S.h); ctx.restore(); }
@@ -604,6 +644,10 @@ return { makeSprite, rasterSprite, loadImages, drawFish, blurSprite, fogSprite, 
   CFG.static = reduced.matches || params.get("motion") === "reduce";
   const canvas = document.getElementById("stage");
   const status = document.getElementById("mood-status");
+  /* Safari paints its own status bar (and, on iOS 26, the strip under its bottom controls) in a colour
+     taken from theme-color or from the nearest fixed element's background; both follow the water. */
+  const theme = document.querySelector('meta[name="theme-color"]');
+  CFG.tint = (color) => { theme.setAttribute("content", color); canvas.style.backgroundColor = color; };
   const buttons = Array.from(document.querySelectorAll(".ctl"));
   function boot(images) {
     if (images && images.length) CFG.raster = images;

--- a/website/tests/site.test.mjs
+++ b/website/tests/site.test.mjs
@@ -65,6 +65,14 @@ test("the shipped page has no runtime network dependency", async () => {
 test("the page keeps essential document and canvas semantics", () => {
   assert.match(page, /<html lang="en">/);
   assert.match(page, /<meta name="viewport"/);
+  /* The water runs edge to edge on phones: the page opts into the notch and
+     bottom-bar areas, the canvas takes the large viewport height, and the
+     chrome keeps to the safe area on every edge. */
+  assert.match(page, /<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">/);
+  assert.match(page, /<meta name="theme-color" content="#[0-9a-f]{6}">/);
+  assert.match(page, /@supports \(-webkit-touch-callout: none\) \{\s*@media \(orientation: portrait\) and \(max-width: 600px\) \{\s*#stage \{ height: 100vh; height: 100lvh; \}/);
+  for (const edge of ["top", "left", "right"]) assert.match(page, new RegExp(`\\.top \\{[^}]*env\\(safe-area-inset-${edge}, 0px\\)`));
+  assert.match(page, /\.bottom \{[^}]*env\(safe-area-inset-bottom, 0px\)/);
   assert.match(page, /<meta name="description"/);
   assert.match(page, /<title>Fathom — ks-design lab<\/title>/);
   assert.match(page, /<canvas id="stage" aria-hidden="true"><\/canvas>/);

--- a/website/tests/site.test.mjs
+++ b/website/tests/site.test.mjs
@@ -70,7 +70,9 @@ test("the page keeps essential document and canvas semantics", () => {
      chrome keeps to the safe area on every edge. */
   assert.match(page, /<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">/);
   assert.match(page, /<meta name="theme-color" content="#[0-9a-f]{6}">/);
-  assert.match(page, /@supports \(-webkit-touch-callout: none\) \{\s*@media \(orientation: portrait\) and \(max-width: 600px\) \{\s*#stage \{ height: 100vh; height: 100lvh; \}/);
+  assert.match(page, /@supports \(-webkit-touch-callout: none\) \{\s*@media \(orientation: portrait\) and \(max-width: 600px\) \{\s*#stage \{ position: absolute; height: calc\(100vh \+ 120px\); height: calc\(100lvh \+ 120px\); \}/);
+  assert.match(page, /html, body \{ height: 100%; overscroll-behavior: none; \}/);
+  assert.match(page, /<div id="tint" aria-hidden="true"><\/div>/);
   for (const edge of ["top", "left", "right"]) assert.match(page, new RegExp(`\\.top \\{[^}]*env\\(safe-area-inset-${edge}, 0px\\)`));
   assert.match(page, /\.bottom \{[^}]*env\(safe-area-inset-bottom, 0px\)/);
   assert.match(page, /<meta name="description"/);


### PR DESCRIPTION
## Summary

- What changed: (1) the water's brush marks are soft washes — tapered polygons painted on two coarse sheets (quarter and half scale), each laid onto the ground blurred once — instead of 700 hard-edged rectangles whose overlapping edges read as vertical stripes and blocks ("seams that look like interference" on desktop); fewer, fainter horizontal marks keep the streaks vertical. (2) Hairlines at fish edges at midnight: every fish is warped on one shared scratch canvas and a bilinear blit reads one texel past its source rectangle, so a smaller fish carried a hairline of the previous larger sprite's glow along its right and bottom edges; the margin is cleared too. Caustic tiles are built at device resolution and scrolled by whole device pixels, so their repeat edge is never resampled. (3) A pace factor lifts fish speed on small screens (`clamp((1000/S.min)^0.4, 1, 1.6)`: 1 at a 1000 px short side, ~1.12 on a 746 px laptop window, ~1.45 on a 390 px phone), applied at layout and rescaled on resize; the frame clamp rises from 0.05 s to 0.1 s so the simulation stays real-time down to 10 fps. (4) `viewport-fit=cover` with the chrome kept inside the safe area on every edge; on iPhones in portrait the canvas is laid out as document content 120 px taller than the large viewport, so the water runs on through the zone of Safari's bottom bar and shows in its glass (Safari clips the page at the document's bottom inside that zone, so a taller fixed canvas was cut and the bar showed Safari's own flat fill); overscroll is disabled on the root. The status bar, which no page can paint, is tinted to the water: `theme-color` (iOS 15–18) and a fixed 8 px strip at the top edge (iOS 26 samples the fixed element it finds there and ignores `theme-color`), both refreshed from the ground's top edge on every mood change and fade. Resize events that change nothing (iPhone Safari sends them on tab switches and bar toggles) no longer rebuild the scene or blank the reduced-motion still frame.
- Why: Kristina's review of production on desktop (striped patches in the water, hairlines at midnight) and on an iPhone (flat strips above and below the scene, fish drifting far too slowly). She approved the result on the stage preview from her iPhone and desktop on 2026-09-07; the README records it as a client decision.
- Product surface affected: the water texture in all three moods; fish edges at midnight; motion on screens with a short side under 1000 px; page layout on phones.

## Content and design evidence

- [x] Facts and copy are sourced or explicitly marked as assumptions — README "Current status" records the client decision of 2026-09-07.
- [x] Third-party assets, fonts, scripts, embeds, and trackers are licensed and justified — none added.
- [x] Smallest/largest layouts, keyboard, reduced motion, and the critical path were checked — see evidence; the iPhone check is Kristina's (approved).
- [x] README, AGENTS, and durable product docs still match the implementation.

## Safety and validation

- [x] No secrets, personal paths, generated output, or unrelated customer data are tracked.
- [x] `npm run preflight` — repository guard 32 paths, harness 14/14, site tests 6/6 (new assertions guard the viewport meta, the iPhone-portrait `#stage` rule, the safe-area paddings, the `theme-color` meta, the root overscroll rule and the tint strip).
- [x] Payload-budget result and any intentional budget change are explained below — no budget change.

## Evidence

- Payload: 458 375 B raw, 411 127 B gzip; critical 23 315 B gzip. `index.html` 69 049 B raw against the 102 400 B budget.
- Desktop artefact measured in Chrome 151 by rendering `K.paintBackground` with `strokes: 0` vs `noise: 0`: the hard bars alone produce the stripes; the noise overlay does not. New wash costs ~9 ms per ground at 3024×1492 (old bars ~19 ms).
- Midnight hairlines located by a per-column/per-row search for straight runs of luminance deviation in the composited frame: runs of 80–240 device px hugging fish rectangles before the fix; after it only fin edges remain. An offscreen render of the caustic pattern at fractional offsets showed no seam, so the pattern was not the cause; the device-pixel tiles are belt and braces.
- Visual check in Chrome (1512×746 @2x and 1568×656): day, dusk and midnight water at 1:1 and zoomed; 390×720 frames for day, midnight and `?motion=reduce` render with the chrome in place.
- Static path: under `?motion=reduce` a phantom `resize` leaves the frame intact (luminance unchanged); a real size change repaints at the new size.
- Speed (px/s, near layer mean): 390×750 phone 14 → 20; 1512×746 laptop 27 → 30; 2000×990 desktop unchanged.
- Stage preview approved by Kristina on iPhone and desktop (2026-09-07): no seams in midnight, natural pace, water visible under Safari's bottom bar. The iOS mechanism (root clipped at the document's bottom inside the bar zone, colour sampled from fixed edge elements, `theme-color` ignored on 26) is from WebKit bug 297779/300965, Apple developer forums 800798/809407 and the Safari 26.1/26.2 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
